### PR TITLE
Wire PinCache into DocMap, ApiMap, Workspace, and Library

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -118,7 +118,7 @@ module Solargraph
       recreate_docmap = @unresolved_requires != unresolved_requires ||
                         # @sg-ignore Unresolved call to rbs_collection_path on Solargraph::Workspace, nil
                         workspace.rbs_collection_path != bench.workspace.rbs_collection_path ||
-                        @doc_map.uncached_gemspecs.any?
+                        @doc_map.any_uncached?
 
       if recreate_docmap
         @doc_map = DocMap.new(unresolved_requires, bench.workspace, out: nil) # @todo Implement gem preferences
@@ -168,16 +168,6 @@ module Solargraph
     # @return [::Array<Gem::Specification>]
     def uncached_gemspecs
       doc_map.uncached_gemspecs || []
-    end
-
-    # @return [::Array<Gem::Specification>]
-    def uncached_rbs_collection_gemspecs
-      @doc_map.uncached_rbs_collection_gemspecs
-    end
-
-    # @return [::Array<Gem::Specification>]
-    def uncached_yard_gemspecs
-      @doc_map.uncached_yard_gemspecs
     end
 
     # @return [Enumerable<Pin::Base>]
@@ -241,7 +231,7 @@ module Solargraph
     # @param rebuild [Boolean] whether to rebuild the pins even if they are cached
     # @return [void]
     def cache_all_for_doc_map! out: $stderr, rebuild: false
-      doc_map.cache_all!(out, rebuild: rebuild)
+      doc_map.cache_doc_map_gems!(out, rebuild: rebuild)
     end
 
     # @param gemspec [Gem::Specification]
@@ -660,6 +650,7 @@ module Solargraph
     # @param cursor [Source::Cursor]
     # @return [SourceMap::Clip]
     def clip cursor
+      # @sg-ignore Need to add nil check here
       raise FileNotFoundError, "ApiMap did not catalog #{cursor.filename}" unless source_map_hash.key?(cursor.filename)
 
       SourceMap::Clip.new(self, cursor)
@@ -751,10 +742,10 @@ module Solargraph
       logger.debug do
         "ApiMap#resolve_method_aliases(pins=#{pins.map(&:name)}, visibility=#{visibility}) => #{with_resolved_aliases.map(&:name)}"
       end
-      with_resolved_aliases
+      GemPins.combine_method_pins_by_path(with_resolved_aliases)
     end
 
-    # @return [Workspace, nil]
+    # @return [Workspace]
     def workspace
       doc_map.workspace
     end

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -5,123 +5,83 @@ require 'benchmark'
 require 'open3'
 
 module Solargraph
-  # A collection of pins generated from required gems.
+  # A collection of pins generated from specific 'require' statements
+  # in code.  Multiple can be created per workspace, to represent the
+  # pins available in different files based on their particular
+  # 'require' lines.
   #
   class DocMap
     include Logging
 
-    # @return [Array<String>]
-    attr_reader :requires
-    alias required requires
-
-    # @return [Array<Gem::Specification>]
-    attr_reader :preferences
-
-    # @return [Array<Pin::Base>]
-    attr_reader :pins
-
-    # @return [Array<Gem::Specification>]
-    def uncached_gemspecs
-      uncached_yard_gemspecs.concat(uncached_rbs_collection_gemspecs)
-                            .sort
-                            .uniq { |gemspec| "#{gemspec.name}:#{gemspec.version}" }
-    end
-
-    # @return [Array<Gem::Specification>]
-    attr_reader :uncached_yard_gemspecs
-
-    # @return [Array<Gem::Specification>]
-    attr_reader :uncached_rbs_collection_gemspecs
-
-    # @return [String, nil]
-    attr_reader :rbs_collection_path
-
-    # @return [String, nil]
-    attr_reader :rbs_collection_config_path
-
-    # @return [Workspace, nil]
+    # @return [Workspace]
     attr_reader :workspace
-
-    # @return [Environ]
-    attr_reader :environ
 
     # @param requires [Array<String>]
     # @param workspace [Workspace, nil]
-    # @param [Object] out
+    # @param out [IO, nil] output stream for logging
     def initialize requires, workspace, out: $stderr
-      @requires = requires.compact
+      @provided_requires = requires.compact
       @workspace = workspace
-      @rbs_collection_path = workspace&.rbs_collection_path
-      @rbs_collection_config_path = workspace&.rbs_collection_config_path
-      @environ = Convention.for_global(self)
-      @requires.concat @environ.requires if @environ
-      load_serialized_gem_pins
-      pins.concat @environ.pins
       @out = out
     end
 
-    # @param out [IO, StringIO, nil]
-    # @return [void]
-    # @param [Boolean] rebuild
-    def cache_all! out, rebuild: false
-      # if we log at debug level:
-      if logger.info?
-        gem_desc = uncached_gemspecs.map { |gemspec| "#{gemspec.name}:#{gemspec.version}" }.join(', ')
-        logger.info "Caching pins for gems: #{gem_desc}" unless uncached_gemspecs.empty?
-      end
-      logger.debug { "Caching for YARD: #{uncached_yard_gemspecs.map(&:name)}" }
-      logger.debug { "Caching for RBS collection: #{uncached_rbs_collection_gemspecs.map(&:name)}" }
-      load_serialized_gem_pins
-      uncached_gemspecs.each do |gemspec|
-        cache(gemspec, rebuild: rebuild, out: out)
-      end
-      load_serialized_gem_pins
-      @uncached_rbs_collection_gemspecs = []
-      @uncached_yard_gemspecs = []
+    # @return [Array<String>]
+    def requires
+      @requires ||= @provided_requires + (workspace.global_environ&.requires || [])
     end
+    alias required requires
 
-    # @param gemspec [Gem::Specification]
-    # @param out [IO, StringIO, nil]
-    # @return [void]
-    def cache_yard_pins gemspec, out
-      pins = GemPins.build_yard_pins(yard_plugins, gemspec)
-      PinCache.serialize_yard_gem(gemspec, pins)
-      logger.info { "Cached #{pins.length} YARD pins for gem #{gemspec.name}:#{gemspec.version}" } unless pins.empty?
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @param out [IO, StringIO, nil]
-    # @return [void]
-    def cache_rbs_collection_pins gemspec, out
-      rbs_map = RbsMap.from_gemspec(gemspec, rbs_collection_path, rbs_collection_config_path)
-      pins = rbs_map.pins
-      rbs_version_cache_key = rbs_map.cache_key
-      # cache pins even if result is zero, so we don't retry building pins
-      pins ||= []
-      PinCache.serialize_rbs_collection_gem(gemspec, rbs_version_cache_key, pins)
-      logger.info { "Cached #{pins.length} RBS collection pins for gem #{gemspec.name} #{gemspec.version} with cache_key #{rbs_version_cache_key.inspect}" unless pins.empty? }
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @param rebuild [Boolean] whether to rebuild the pins even if they are cached
-    # @param out [IO, StringIO, nil] output stream for logging
-    # @return [void]
-    def cache gemspec, rebuild: false, out: nil
-      build_yard = uncached_yard_gemspecs.include?(gemspec) || rebuild
-      build_rbs_collection = uncached_rbs_collection_gemspecs.include?(gemspec) || rebuild
-      if build_yard || build_rbs_collection
-        type = []
-        type << 'YARD' if build_yard
-        type << 'RBS collection' if build_rbs_collection
-        out&.puts("Caching #{type.join(' and ')} pins for gem #{gemspec.name}:#{gemspec.version}")
-      end
-      cache_yard_pins(gemspec, out) if build_yard
-      cache_rbs_collection_pins(gemspec, out) if build_rbs_collection
-    end
-
+    # @sg-ignore flow sensitive typing needs to understand reassignment
     # @return [Array<Gem::Specification>]
-    def gemspecs
-      @gemspecs ||= required_gems_map.values.compact.flatten
+    def uncached_gemspecs
+      if @uncached_gemspecs.nil?
+        @uncached_gemspecs = []
+        pins # force lazy-loaded pin lookup
+      end
+      @uncached_gemspecs
+    end
+
+    # @return [Array<Pin::Base>]
+    def pins
+      @pins ||= load_serialized_gem_pins + (workspace.global_environ&.pins || [])
+    end
+
+    # @return [void]
+    def reset_pins!
+      @uncached_gemspecs = nil
+      @pins = nil
+    end
+
+    # @return [Solargraph::PinCache]
+    def pin_cache
+      @pin_cache ||= workspace.fresh_pincache
+    end
+
+    def any_uncached?
+      uncached_gemspecs.any?
+    end
+
+    # Cache all pins needed for the sources in this doc_map
+    # @param out [StringIO, IO, nil] output stream for logging
+    # @param rebuild [Boolean] whether to rebuild the pins even if they are cached
+    # @return [void]
+    def cache_doc_map_gems! out, rebuild: false
+      unless uncached_gemspecs.empty?
+        logger.info do
+          gem_desc = uncached_gemspecs.map { |gemspec| "#{gemspec.name}:#{gemspec.version}" }.join(', ')
+          "Caching pins for gems: #{gem_desc}"
+        end
+      end
+      time = Benchmark.measure do
+        uncached_gemspecs.each do |gemspec|
+          cache(gemspec, rebuild: rebuild, out: out)
+        end
+      end
+      milliseconds = (time.real * 1000).round
+      if (milliseconds > 500) && uncached_gemspecs.any? && out && uncached_gemspecs.any?
+        out.puts "Built #{uncached_gemspecs.length} gems in #{milliseconds} ms"
+      end
+      reset_pins!
     end
 
     # @return [Array<String>]
@@ -129,311 +89,108 @@ module Solargraph
       @unresolved_requires ||= required_gems_map.select { |_, gemspecs| gemspecs.nil? }.keys
     end
 
-    # @return [Hash{Array(String, String) => Array<Pin::Base>}] Indexed by gemspec name and version
-    def self.all_yard_gems_in_memory
-      @all_yard_gems_in_memory ||= {}
+    # @return [Array<Gem::Specification>]
+    # @param out [IO, nil]
+    def dependencies out: $stderr
+      @dependencies ||=
+        begin
+          gem_deps = gemspecs
+                     .flat_map { |spec| workspace.fetch_dependencies(spec, out: out) }
+                     .uniq(&:name)
+          stdlib_deps = gemspecs
+                        .flat_map { |spec| workspace.stdlib_dependencies(spec.name) }
+                        .flat_map { |dep_name| workspace.resolve_require(dep_name) }
+                        .compact
+          existing_gems = gemspecs.map(&:name)
+          (gem_deps + stdlib_deps).reject { |gemspec| existing_gems.include? gemspec.name }
+        end
     end
 
-    # @return [Hash{String => Hash{Array(String, String) => Array<Pin::Base>}}] stored by RBS collection path
-    def self.all_rbs_collection_gems_in_memory
-      @all_rbs_collection_gems_in_memory ||= {}
-    end
-
-    # @return [Hash{Array(String, String) => Array<Pin::Base>}] Indexed by gemspec name and version
-    def yard_pins_in_memory
-      self.class.all_yard_gems_in_memory
-    end
-
-    # @return [Hash{Array(String, String) => Array<Pin::Base>}] Indexed by gemspec name and version
-    def rbs_collection_pins_in_memory
-      # @sg-ignore rbs_collection_path is String | nil but used as hash key
-      self.class.all_rbs_collection_gems_in_memory[rbs_collection_path] ||= {}
-    end
-
-    # @return [Hash{Array(String, String) => Array<Pin::Base>}] Indexed by gemspec name and version
-    def self.all_combined_pins_in_memory
-      @all_combined_pins_in_memory ||= {}
-    end
-
-    # @todo this should also include an index by the hash of the RBS collection
-    # @return [Hash{Array(String, String) => Array<Pin::Base>}] Indexed by gemspec name and version
-    def combined_pins_in_memory
-      self.class.all_combined_pins_in_memory
-    end
-
-    # @return [Array<String>]
-    def yard_plugins
-      @environ.yard_plugins
-    end
-
-    # @return [Set<Gem::Specification>]
-    def dependencies
-      @dependencies ||= (gemspecs.flat_map { |spec| fetch_dependencies(spec) } - gemspecs).to_set
+    # Cache gem documentation if needed for this doc_map
+    #
+    # @param gemspec [Gem::Specification]
+    # @param rebuild [Boolean] whether to rebuild the pins even if they are cached
+    # @param out [StringIO, IO, nil] output stream for logging
+    #
+    # @return [void]
+    def cache gemspec, rebuild: false, out: nil
+      pin_cache.cache_gem(gemspec: gemspec,
+                          rebuild: rebuild,
+                          out: out)
     end
 
     private
 
-    # @return [void]
-    def load_serialized_gem_pins
-      @pins = []
-      @uncached_yard_gemspecs = []
-      @uncached_rbs_collection_gemspecs = []
+    # @return [Array<Gem::Specification>]
+    def gemspecs
+      @gemspecs ||= required_gems_map.values.compact.flatten
+    end
+
+    # @param out [IO, nil]
+    # @return [Array<Pin::Base>]
+    def load_serialized_gem_pins out: @out
+      serialized_pins = []
       with_gemspecs, without_gemspecs = required_gems_map.partition { |_, v| v }
       # @type [Array<String>]
-      paths = without_gemspecs.to_h.keys
+      missing_paths = without_gemspecs.to_h.keys
       # @type [Array<Gem::Specification>]
-      gemspecs = with_gemspecs.to_h.values.flatten.compact + dependencies.to_a
+      gemspecs = with_gemspecs.to_h.values.flatten.compact + dependencies(out: out).to_a
 
-      paths.each do |path|
-        deserialize_stdlib_rbs_map path
+      # if we are type checking a gem project, we should not include
+      # pins from rbs or yard from that gem here - we use our own
+      # parser for those pins
+
+      # @param gemspec [Gem::Specification, Bundler::LazySpecification, Bundler::StubSpecification]
+      gemspecs.reject! do |gemspec|
+        gemspec.respond_to?(:source) &&
+          gemspec.source.instance_of?(Bundler::Source::Gemspec) &&
+          gemspec.source.respond_to?(:path) &&
+          gemspec.source.path == Pathname.new('.')
       end
 
-      logger.debug { 'DocMap#load_serialized_gem_pins: Combining pins...' }
-      time = Benchmark.measure do
-        gemspecs.each do |gemspec|
-          pins = deserialize_combined_pin_cache gemspec
-          @pins.concat pins if pins
+      missing_paths.each do |path|
+        # this will load from disk if needed; no need to manage
+        # uncached_gemspecs to trigger that later
+        stdlib_name_guess = path.split('/').first
+
+        # try to resolve the stdlib name
+        # @type [Array<String>]
+        deps = workspace.stdlib_dependencies(stdlib_name_guess) || []
+        [stdlib_name_guess, *deps].compact.each do |potential_stdlib_name|
+          # @sg-ignore Need to support splatting in literal array
+          rbs_pins = pin_cache.cache_stdlib_rbs_map potential_stdlib_name
+          serialized_pins.concat rbs_pins if rbs_pins
         end
       end
-      logger.info { "DocMap#load_serialized_gem_pins: Loaded and processed serialized pins together in #{time.real} seconds" }
-      @uncached_yard_gemspecs.uniq!
-      @uncached_rbs_collection_gemspecs.uniq!
-      nil
+
+      serialized_pins.length
+      time = Benchmark.measure do
+        gemspecs.each do |gemspec|
+          # only deserializes already-cached gems
+          gemspec_pins = pin_cache.deserialize_combined_pin_cache gemspec
+          if gemspec_pins
+            serialized_pins.concat gemspec_pins
+          else
+            uncached_gemspecs << gemspec
+          end
+        end
+      end
+      serialized_pins.length
+      milliseconds = (time.real * 1000).round
+      if (milliseconds > 500) && out && gemspecs.any?
+        out.puts "Deserialized #{serialized_pins.length} gem pins from #{PinCache.base_dir} in #{milliseconds} ms"
+      end
+      uncached_gemspecs.uniq! { |gemspec| "#{gemspec.name}:#{gemspec.version}" }
+      serialized_pins
     end
 
     # @return [Hash{String => Array<Gem::Specification>}]
     def required_gems_map
-      @required_gems_map ||= requires.to_h { |path| [path, resolve_path_to_gemspecs(path)] }
-    end
-
-    # @return [Hash{String => Gem::Specification}]
-    def preference_map
-      @preference_map ||= preferences.to_h { |gemspec| [gemspec.name, gemspec] }
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @return [Array<Pin::Base>, nil]
-    def deserialize_yard_pin_cache gemspec
-      if yard_pins_in_memory.key?([gemspec.name, gemspec.version])
-        return yard_pins_in_memory[[gemspec.name, gemspec.version]]
-      end
-
-      cached = PinCache.deserialize_yard_gem(gemspec)
-      if cached
-        logger.info { "Loaded #{cached.length} cached YARD pins from #{gemspec.name}:#{gemspec.version}" }
-        yard_pins_in_memory[[gemspec.name, gemspec.version]] = cached
-        cached
-      else
-        logger.debug "No YARD pin cache for #{gemspec.name}:#{gemspec.version}"
-        @uncached_yard_gemspecs.push gemspec
-        nil
-      end
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @return [void]
-    def deserialize_combined_pin_cache gemspec
-      unless combined_pins_in_memory[[gemspec.name, gemspec.version]].nil?
-        return combined_pins_in_memory[[gemspec.name, gemspec.version]]
-      end
-
-      rbs_map = RbsMap.from_gemspec(gemspec, rbs_collection_path, rbs_collection_config_path)
-      rbs_version_cache_key = rbs_map.cache_key
-
-      cached = PinCache.deserialize_combined_gem(gemspec, rbs_version_cache_key)
-      if cached
-        logger.info { "Loaded #{cached.length} cached YARD pins from #{gemspec.name}:#{gemspec.version}" }
-        combined_pins_in_memory[[gemspec.name, gemspec.version]] = cached
-        return combined_pins_in_memory[[gemspec.name, gemspec.version]]
-      end
-
-      rbs_collection_pins = deserialize_rbs_collection_cache gemspec, rbs_version_cache_key
-
-      yard_pins = deserialize_yard_pin_cache gemspec
-
-      if !rbs_collection_pins.nil? && !yard_pins.nil?
-        logger.debug { "Combining pins for #{gemspec.name}:#{gemspec.version}" }
-        combined_pins = GemPins.combine(yard_pins, rbs_collection_pins)
-        PinCache.serialize_combined_gem(gemspec, rbs_version_cache_key, combined_pins)
-        combined_pins_in_memory[[gemspec.name, gemspec.version]] = combined_pins
-        logger.info { "Generated #{combined_pins_in_memory[[gemspec.name, gemspec.version]].length} combined pins for #{gemspec.name} #{gemspec.version}" }
-        return combined_pins
-      end
-
-      if !yard_pins.nil?
-        logger.debug { "Using only YARD pins for #{gemspec.name}:#{gemspec.version}" }
-        combined_pins_in_memory[[gemspec.name, gemspec.version]] = yard_pins
-        combined_pins_in_memory[[gemspec.name, gemspec.version]]
-      elsif !rbs_collection_pins.nil?
-        logger.debug { "Using only RBS collection pins for #{gemspec.name}:#{gemspec.version}" }
-        combined_pins_in_memory[[gemspec.name, gemspec.version]] = rbs_collection_pins
-        combined_pins_in_memory[[gemspec.name, gemspec.version]]
-      else
-        logger.debug { "Pins not yet cached for #{gemspec.name}:#{gemspec.version}" }
-        nil
-      end
-    end
-
-    # @param path [String] require path that might be in the RBS stdlib collection
-    # @return [void]
-    def deserialize_stdlib_rbs_map path
-      map = RbsMap::StdlibMap.load(path)
-      if map.resolved?
-        logger.debug { "Loading stdlib pins for #{path}" }
-        @pins.concat map.pins
-        logger.debug { "Loaded #{map.pins.length} stdlib pins for #{path}" }
-        map.pins
-      else
-        # @todo Temporarily ignoring unresolved `require 'set'`
-        logger.debug { "Require path #{path} could not be resolved in RBS" } unless path == 'set'
-        nil
-      end
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @param rbs_version_cache_key [String]
-    # @return [Array<Pin::Base>, nil]
-    def deserialize_rbs_collection_cache gemspec, rbs_version_cache_key
-      return if rbs_collection_pins_in_memory.key?([gemspec, rbs_version_cache_key])
-      cached = PinCache.deserialize_rbs_collection_gem(gemspec, rbs_version_cache_key)
-      if cached
-        logger.info { "Loaded #{cached.length} pins from RBS collection cache for #{gemspec.name}:#{gemspec.version}" } unless cached.empty?
-        rbs_collection_pins_in_memory[[gemspec, rbs_version_cache_key]] = cached
-        cached
-      else
-        logger.debug "No RBS collection pin cache for #{gemspec.name} #{gemspec.version}"
-        @uncached_rbs_collection_gemspecs.push gemspec
-        nil
-      end
-    end
-
-    # @param path [String]
-    # @return [::Array<Gem::Specification>, nil]
-    def resolve_path_to_gemspecs path
-      return nil if path.empty?
-      return gemspecs_required_from_bundler if path == 'bundler/require'
-
-      # @type [Gem::Specification, nil]
-      gemspec = Gem::Specification.find_by_path(path)
-      if gemspec.nil?
-        gem_name_guess = path.split('/').first
-        return nil if gem_name_guess.to_s.empty?
-        begin
-          # this can happen when the gem is included via a local path in
-          # a Gemfile; Gem doesn't try to index the paths in that case.
-          #
-          # See if we can make a good guess:
-          gemspec = Gem::Specification.find_by_name(gem_name_guess)
-        rescue Gem::MissingSpecError
-          logger.debug { "Require path #{path} could not be resolved to a gem via find_by_path or guess of #{gem_name_guess}" }
-          []
-        end
-      end
-      return nil if gemspec.nil?
-      [gemspec_or_preference(gemspec)]
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @return [Gem::Specification]
-    def gemspec_or_preference gemspec
-      # :nocov: dormant feature
-      return gemspec unless preference_map.key?(gemspec.name)
-      return gemspec if gemspec.version == preference_map[gemspec.name].version
-
-      change_gemspec_version gemspec, preference_map[gemspec.name].version
-      # :nocov:
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @param version [Gem::Version, String]
-    # @return [Gem::Specification]
-    def change_gemspec_version gemspec, version
-      Gem::Specification.find_by_name(gemspec.name, "= #{version}")
-    rescue Gem::MissingSpecError
-      Solargraph.logger.info "Gem #{gemspec.name} version #{version} not found. Using #{gemspec.version} instead"
-      gemspec
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @return [Array<Gem::Specification>]
-    def fetch_dependencies gemspec
-      # @param spec [Gem::Dependency]
-      # @param deps [Set<Gem::Specification>]
-      only_runtime_dependencies(gemspec).each_with_object(Set.new) do |spec, deps|
-        Solargraph.logger.info "Adding #{spec.name} dependency for #{gemspec.name}"
-        dep = Gem.loaded_specs[spec.name]
-        # @todo is next line necessary?
-        dep ||= Gem::Specification.find_by_name(spec.name, spec.requirement)
-        deps.merge fetch_dependencies(dep) if deps.add?(dep)
-      rescue Gem::MissingSpecError
-        Solargraph.logger.warn "Gem dependency #{spec.name} for #{gemspec.name} not found in RubyGems."
-      end.to_a
-    end
-
-    # @param gemspec [Gem::Specification]
-    # @return [Array<Gem::Dependency>]
-    def only_runtime_dependencies gemspec
-      gemspec.dependencies - gemspec.development_dependencies
+      @required_gems_map ||= requires.to_h { |path| [path, workspace.resolve_require(path)] }
     end
 
     def inspect
       self.class.inspect
-    end
-
-    # @return [Array<Gem::Specification>, nil]
-    def gemspecs_required_from_bundler
-      # @todo Handle projects with custom Bundler/Gemfile setups
-      return unless workspace&.gemfile?
-
-      # @sg-ignore workspace is checked for nil above
-      if workspace.gemfile? && Bundler.definition&.lockfile&.to_s&.start_with?(workspace.directory) # rubocop:disable Style/SafeNavigationChainLength
-        # Find only the gems bundler is now using
-        Bundler.definition.locked_gems.specs.flat_map do |lazy_spec|
-          logger.info "Handling #{lazy_spec.name}:#{lazy_spec.version}"
-          [Gem::Specification.find_by_name(lazy_spec.name, lazy_spec.version)]
-        rescue Gem::MissingSpecError => e
-          logger.info("Could not find #{lazy_spec.name}:#{lazy_spec.version} with find_by_name, falling back to guess")
-          # can happen in local filesystem references
-          specs = resolve_path_to_gemspecs lazy_spec.name
-          logger.warn "Gem #{lazy_spec.name} #{lazy_spec.version} from bundle not found: #{e}" if specs.nil?
-          next specs
-        end.compact
-      else
-        logger.info 'Fetching gemspecs required from Bundler (bundler/require)'
-        gemspecs_required_from_external_bundle
-      end
-    end
-
-    # @return [Array<Gem::Specification>]
-    def gemspecs_required_from_external_bundle
-      logger.info 'Fetching gemspecs required from external bundle'
-      return [] unless workspace&.directory
-
-      Solargraph.with_clean_env do
-        cmd = [
-          'ruby', '-e',
-          # @sg-ignore return above ensures workspace.directory is not nil
-          "require 'bundler'; require 'json'; Dir.chdir('#{workspace.directory}') { puts Bundler.definition.locked_gems.specs.map { |spec| [spec.name, spec.version] }.to_h.to_json }"
-        ]
-        o, e, s = Open3.capture3(*cmd)
-        if s.success?
-          Solargraph.logger.debug "External bundle: #{o}"
-          hash = o && !o.empty? ? JSON.parse(o.split("\n").last) : {}
-          hash.flat_map do |name, version|
-            Gem::Specification.find_by_name(name, version)
-          rescue Gem::MissingSpecError => e
-            logger.info("Could not find #{name}:#{version} with find_by_name, falling back to guess")
-            # can happen in local filesystem references
-            specs = resolve_path_to_gemspecs name
-            logger.warn "Gem #{name} #{version} from bundle not found: #{e}" if specs.nil?
-            next specs
-          end.compact
-        else
-          # @sg-ignore return above ensures workspace.directory is not nil
-          Solargraph.logger.warn "Failed to load gems from bundle at #{workspace.directory}: #{e}"
-          []
-        end
-      end
     end
   end
 end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
+require 'rubygems'
 require 'pathname'
 require 'observer'
 require 'open3'
+
+# @!parse
+#   class ::Gem::Specification
+#     # @return [String]
+#     def name; end
+#   end
 
 module Solargraph
   # A Library handles coordination between a Workspace and an ApiMap.
@@ -33,6 +40,7 @@ module Solargraph
       # @type [Source, nil]
       @current = nil
       @sync_count = 0
+      @cache_progress = nil
     end
 
     def inspect
@@ -265,11 +273,13 @@ module Solargraph
           referenced&.path == pin.path
         end
         if pin.path == 'Class#new'
+          # @todo flow sensitive typing should allow shadowing of Kernel#caller
           caller = cursor.chain.base.infer(api_map, clip.send(:closure), clip.locals).first
           if caller.defined?
             found.select! do |loc|
               clip = api_map.clip_at(loc.filename, loc.range.start)
               other = clip.send(:cursor).chain.base.infer(api_map, clip.send(:closure), clip.locals).first
+              # @todo flow sensitive typing should allow shadowing of Kernel#caller
               caller == other
             end
           else
@@ -283,9 +293,7 @@ module Solargraph
             Solargraph::Location.new(loc.filename, Solargraph::Range.from_to(loc.range.start.line, loc.range.start.column + match[0].length, loc.range.ending.line, loc.range.ending.column))
           end
         end
-        result.concat(found.sort do |a, b|
-          a.range.start.line <=> b.range.start.line
-        end)
+        result.concat(found.sort { |a, b| a.range.start.line <=> b.range.start.line })
       end
       result.uniq
     end
@@ -310,9 +318,7 @@ module Solargraph
       return nil if pin.nil?
       # @param full [String]
       return_if_match = proc do |full|
-        if source_map_hash.key?(full)
-          return Location.new(full, Solargraph::Range.from_to(0, 0, 0, 0))
-        end
+        return Location.new(full, Solargraph::Range.from_to(0, 0, 0, 0)) if source_map_hash.key?(full)
       end
       workspace.require_paths.each do |path|
         full = File.join path, pin.name
@@ -480,6 +486,7 @@ module Solargraph
     # @return [SourceMap, Boolean]
     def next_map
       return false if mapped?
+      # @sg-ignore Need to add nil check here
       src = workspace.sources.find { |s| !source_map_hash.key?(s.filename) }
       if src
         Logging.logger.debug "Mapping #{src.filename}"
@@ -514,6 +521,11 @@ module Solargraph
     end
 
     private
+
+    # @return [PinCache]
+    def pin_cache
+      workspace.pin_cache
+    end
 
     # @return [Hash{String => Array<String>}]
     def source_map_external_require_hash
@@ -576,6 +588,7 @@ module Solargraph
       return unless source
       # @sg-ignore Wrong argument type for Solargraph::Workspace#has_file?: filename expected String, received String, nil
       return unless @current == source || workspace.has_file?(source.filename)
+      # @sg-ignore Need to add nil check here
       if source_map_hash.key?(source.filename)
         new_map = Solargraph::SourceMap.map(source)
         # @sg-ignore OK if source.filename is nil
@@ -600,7 +613,7 @@ module Solargraph
 
       pending = api_map.uncached_gemspecs.length - cache_errors.length - 1
 
-      if Yardoc.processing?(spec)
+      if pin_cache.yardoc_processing?(spec)
         logger.info "Enqueuing cache of #{spec.name} #{spec.version} (already being processed)"
         queued_gemspec_cache.push(spec)
         return if pending - queued_gemspec_cache.length < 1
@@ -611,7 +624,10 @@ module Solargraph
         logger.info "Caching #{spec.name} #{spec.version}"
         Thread.new do
           report_cache_progress spec.name, pending
-          _o, e, s = Open3.capture3(workspace.command_path, 'cache', spec.name, spec.version.to_s)
+          kwargs = {}
+          kwargs[:chdir] = workspace.directory.to_s if workspace.directory && !workspace.directory.empty?
+          _o, e, s = Open3.capture3(workspace.command_path, 'cache', spec.name, spec.version.to_s,
+                                    **kwargs)
           if s.success?
             logger.info "Cached #{spec.name} #{spec.version}"
           else
@@ -628,8 +644,7 @@ module Solargraph
 
     # @return [Array<Gem::Specification>]
     def cacheable_specs
-      cacheable = api_map.uncached_yard_gemspecs +
-                  api_map.uncached_rbs_collection_gemspecs -
+      cacheable = api_map.uncached_gemspecs +
                   queued_gemspec_cache -
                   cache_errors.to_a
       return cacheable unless cacheable.empty?
@@ -692,8 +707,7 @@ module Solargraph
         source_map_hash.each_value { |map| find_external_requires(map) }
         api_map.catalog bench
         logger.info "Catalog complete (#{api_map.source_maps.length} files, #{api_map.pins.length} pins)"
-        logger.info "#{api_map.uncached_yard_gemspecs.length} uncached YARD gemspecs"
-        logger.info "#{api_map.uncached_rbs_collection_gemspecs.length} uncached RBS collection gemspecs"
+        logger.info "#{api_map.uncached_gemspecs.length} uncached gemspecs"
         cache_next_gemspec
         @sync_count = 0
       end

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -2,6 +2,7 @@
 
 require 'open3'
 require 'json'
+require 'yaml'
 
 module Solargraph
   # A workspace consists of the files in a project's directory and the
@@ -9,6 +10,8 @@ module Solargraph
   # in an associated Library or ApiMap.
   #
   class Workspace
+    include Logging
+
     autoload :Config, 'solargraph/workspace/config'
     autoload :Gemspecs, 'solargraph/workspace/gemspecs'
     autoload :RequirePaths, 'solargraph/workspace/require_paths'
@@ -16,11 +19,8 @@ module Solargraph
     # @return [String]
     attr_reader :directory
 
-    # @return [Array<String>]
-    attr_reader :gemnames
-    alias source_gems gemnames
-
-    # @param directory [String] TODO: Remove '' and '*' special cases
+    # @todo Remove '' and '*' special cases
+    # @param directory [String]
     # @param config [Config, nil]
     # @param server [Hash]
     def initialize directory = '', config = nil, server = {}
@@ -34,7 +34,6 @@ module Solargraph
       @config = config
       @server = server
       load_sources
-      @gemnames = []
       require_plugins
     end
 
@@ -51,6 +50,69 @@ module Solargraph
       @config ||= Solargraph::Workspace::Config.new(directory)
     end
 
+    # @param stdlib_name [String]
+    #
+    # @return [Array<String>]
+    def stdlib_dependencies stdlib_name
+      gemspecs.stdlib_dependencies(stdlib_name)
+    end
+
+    # @param out [IO, nil] output stream for logging
+    # @param gemspec [Gem::Specification]
+    # @return [Array<Gem::Specification>]
+    def fetch_dependencies gemspec, out: $stderr
+      gemspecs.fetch_dependencies(gemspec, out: out)
+    end
+
+    # @param require [String] The string sent to 'require' in the code to resolve, e.g. 'rails', 'bundler/require'
+    #
+    # @return [Array<Gem::Specification>, nil]
+    def resolve_require require
+      gemspecs.resolve_require(require)
+    end
+
+    # @return [Solargraph::PinCache]
+    def pin_cache
+      @pin_cache ||= fresh_pincache
+    end
+
+    # @return [Environ]
+    def global_environ
+      # empty docmap, since the result needs to work in any possible
+      # context here
+      @global_environ ||= Convention.for_global(DocMap.new([], self, out: nil))
+    end
+
+    # @param gemspec [Gem::Specification]
+    # @param out [StringIO, IO, nil] output stream for logging
+    # @param rebuild [Boolean] whether to rebuild the pins even if they are cached
+    #
+    # @return [void]
+    def cache_gem gemspec, out: nil, rebuild: false
+      pin_cache.cache_gem(gemspec: gemspec, out: out, rebuild: rebuild)
+    end
+
+    # @param gemspec [Gem::Specification, Bundler::LazySpecification]
+    # @param out [StringIO, IO, nil] output stream for logging
+    #
+    # @return [void]
+    def uncache_gem gemspec, out: nil
+      pin_cache.uncache_gem(gemspec, out: out)
+    end
+
+    # @return [Solargraph::PinCache]
+    def fresh_pincache
+      PinCache.new(rbs_collection_path: rbs_collection_path,
+                   rbs_collection_config_path: rbs_collection_config_path,
+                   yard_plugins: yard_plugins,
+                   directory: directory)
+    end
+
+    # @return [Array<String>]
+    def yard_plugins
+      @yard_plugins ||= global_environ.yard_plugins.sort.uniq
+    end
+
     # @param level [Symbol]
     # @return [TypeChecker::Rules]
     def rules level
@@ -64,6 +126,7 @@ module Solargraph
     # @param sources [Array<Solargraph::Source>]
     # @return [Boolean] True if the source was added to the workspace
     def merge *sources
+      # @sg-ignore Need to add nil check here
       unless directory == '*' || sources.all? { |source| source_hash.key?(source.filename) }
         # Reload the config to determine if a new source should be included
         @config = Solargraph::Workspace::Config.new(directory)
@@ -128,48 +191,6 @@ module Solargraph
       false
     end
 
-    # @return [String, nil]
-    def rbs_collection_path
-      @rbs_collection_path ||= read_rbs_collection_path
-    end
-
-    # @return [String, nil]
-    def rbs_collection_config_path
-      @rbs_collection_config_path ||= unless directory.empty? || directory == '*'
-                                        yaml_file = File.join(directory, 'rbs_collection.yaml')
-                                        yaml_file if File.file?(yaml_file)
-                                      end
-    end
-
-    # @param name [String]
-    # @param version [String, nil]
-    # @param out [IO, nil]
-    #
-    # @return [Gem::Specification, nil]
-    def find_gem name, version = nil, out: nil
-      Gem::Specification.find_by_name(name, version)
-    end
-
-    # Synchronize the workspace from the provided updater.
-    #
-    # @param updater [Source::Updater]
-    # @return [void]
-    def synchronize! updater
-      source_hash[updater.filename] = source_hash[updater.filename].synchronize(updater)
-    end
-
-    # @sg-ignore return type could not be inferred
-    # @return [String]
-    def command_path
-      server['commandPath'] || 'solargraph'
-    end
-
-    # @return [String, nil]
-    def directory_or_nil
-      return nil if directory.empty? || directory == '*'
-      directory
-    end
-
     # True if the workspace has a root Gemfile.
     #
     # @todo Handle projects with custom Bundler/Gemfile setups (see DocMap#gemspecs_required_from_bundler)
@@ -193,6 +214,81 @@ module Solargraph
       @gemspec_files ||= Dir[File.join(directory, '**/*.gemspec')].select do |gs|
         config.allow? gs
       end
+    end
+
+    # @return [String, nil]
+    def rbs_collection_path
+      @rbs_collection_path ||= read_rbs_collection_path
+    end
+
+    # @return [String, nil]
+    def rbs_collection_config_path
+      @rbs_collection_config_path ||= unless directory.empty? || directory == '*'
+                                        yaml_file = File.join(directory, 'rbs_collection.yaml')
+                                        yaml_file if File.file?(yaml_file)
+                                      end
+    end
+
+    # @param name [String]
+    # @param version [String, nil]
+    # @param out [IO, nil]
+    #
+    # @return [Gem::Specification, nil]
+    def find_gem name, version = nil, out: nil
+      gemspecs.find_gem(name, version, out: out)
+    end
+
+    # @return [Array<Gem::Specification>]
+    def all_gemspecs_from_bundle
+      gemspecs.all_gemspecs_from_bundle
+    end
+
+    # @param out [StringIO, IO, nil] output stream for logging
+    # @param rebuild [Boolean] whether to rebuild the pins even if they are cached
+    # @return [void]
+    def cache_all_for_workspace! out, rebuild: false
+      PinCache.cache_core(out: out) unless PinCache.core? && !rebuild
+
+      gem_specs = all_gemspecs_from_bundle
+      # try any possible standard libraries, but be quiet about it
+      stdlib_specs = pin_cache.possible_stdlibs.map { |stdlib| find_gem(stdlib, out: nil) }.compact
+      specs = (gem_specs + stdlib_specs)
+      specs.each do |spec|
+        pin_cache.cache_gem(gemspec: spec, rebuild: rebuild, out: out) unless pin_cache.cached?(spec)
+      end
+      out&.puts "Documentation cached for all #{specs.length} gems."
+
+      # do this after so that we prefer stdlib requires from gems,
+      # which are likely to be newer and have more pins
+      pin_cache.cache_all_stdlibs(out: out, rebuild: rebuild)
+
+      out&.puts 'Documentation cached for core, standard library and gems.'
+    end
+
+    # Synchronize the workspace from the provided updater.
+    #
+    # @param updater [Source::Updater]
+    # @return [void]
+    def synchronize! updater
+      source_hash[updater.filename] = source_hash[updater.filename].synchronize(updater)
+    end
+
+    # @sg-ignore return type could not be inferred
+    # @return [String]
+    # @sg-ignore Need to validate config
+    def command_path
+      server['commandPath'] || 'solargraph'
+    end
+
+    # @return [String, nil]
+    def directory_or_nil
+      return nil if directory.empty? || directory == '*'
+      directory
+    end
+
+    # @return [Solargraph::Workspace::Gemspecs]
+    def gemspecs
+      @gemspecs ||= Solargraph::Workspace::Gemspecs.new(directory_or_nil)
     end
 
     private

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -117,15 +117,15 @@ describe Solargraph::ApiMap do
     end
   end
 
-  describe '#get_method_stack' do
+  describe '#get_method_stack', time_limit_seconds: 240 do
     let(:out) { StringIO.new }
     let(:api_map) { described_class.load_with_cache(Dir.pwd, out) }
 
-    context 'with stdlib that has vital dependencies' do
+    context 'with stdlib that has vital dependencies', time_limit_seconds: 240 do
       let(:external_requires) { ['yaml'] }
       let(:method_stack) { api_map.get_method_stack('YAML', 'safe_load', scope: :class) }
 
-      it 'handles the YAML gem aliased to Psych' do
+      it 'handles the YAML gem aliased to Psych', time_limit_seconds: 240 do
         expect(method_stack).not_to be_empty
       end
     end
@@ -143,10 +143,10 @@ describe Solargraph::ApiMap do
   describe '#cache_all_for_doc_map!' do
     it 'can cache gems without a bench' do
       api_map = described_class.new
-      doc_map = instance_double(Solargraph::DocMap, cache_all!: true)
+      doc_map = instance_double(Solargraph::DocMap, cache_doc_map_gems!: true)
       allow(Solargraph::DocMap).to receive(:new).and_return(doc_map)
       api_map.cache_all_for_doc_map!(out: $stderr)
-      expect(doc_map).to have_received(:cache_all!).with($stderr, rebuild: false)
+      expect(doc_map).to have_received(:cache_doc_map_gems!).with($stderr, rebuild: false)
     end
   end
 

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -7,7 +7,7 @@ describe Solargraph::ApiMap do
     @api_map = described_class.new
   end
 
-  it 'returns core methods' do
+  it 'returns core methods', time_limit_seconds: 120 do
     pins = @api_map.get_methods('String')
     expect(pins.map(&:path)).to include('String#upcase')
   end

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -19,7 +19,7 @@ describe Solargraph::DocMap do
   let(:plain_doc_map) { described_class.new([], workspace, out: nil) }
 
   before do
-    doc_map.cache_all!(nil) if pre_cache
+    doc_map.cache_doc_map_gems!(nil) if pre_cache
   end
 
   context 'with a require in solargraph test bundle' do
@@ -67,18 +67,48 @@ describe Solargraph::DocMap do
     end
   end
 
-  it 'does not warn for redundant requires' do
-    # Requiring 'set' is unnecessary because it's already included in core. It
-    # might make sense to log redundant requires, but a warning is overkill.
-    allow(Solargraph.logger).to receive(:warn).and_call_original
-    described_class.new(['set'], workspace)
-    expect(Solargraph.logger).not_to have_received(:warn).with(/path set/)
+  context 'when deserialization takes a while' do
+    let(:pre_cache) { false }
+    let(:requires) { ['backport'] }
+
+    before do
+      # proxy this method to simulate a long-running deserialization
+      allow(Benchmark).to receive(:measure) do |&block|
+        block.call
+        5.0
+      end
+    end
+
+    it 'logs timing' do
+      # force lazy evaluation
+      _pins = doc_map.pins
+      expect(out.string).to include('Deserialized ').and include(' gem pins ').and include(' ms')
+    end
+  end
+
+  context 'with an uncached but valid gemspec' do
+    let(:requires) { ['uncached_gem'] }
+    let(:pre_cache) { false }
+    let(:workspace) { instance_double(Solargraph::Workspace) }
+
+    it 'tracks uncached_gemspecs' do
+      pincache = instance_double(Solargraph::PinCache, cache_stdlib_rbs_map: false)
+      uncached_gemspec = Gem::Specification.new('uncached_gem', '1.0.0')
+      allow(workspace).to receive(:fetch_dependencies).with(uncached_gemspec, out: out).and_return([])
+      allow(workspace).to receive_messages(fresh_pincache: pincache, resolve_require: [uncached_gemspec],
+                                           stdlib_dependencies: [], global_environ: Solargraph::Environ.new)
+      allow(Gem::Specification).to receive(:find_by_path).with('uncached_gem').and_return(uncached_gemspec)
+      allow(workspace).to receive(:global_environ).and_return(Solargraph::Environ.new)
+      allow(pincache).to receive(:deserialize_combined_pin_cache).with(uncached_gemspec).and_return(nil)
+
+      expect(doc_map.uncached_gemspecs).to eq([uncached_gemspec])
+    end
   end
 
   context 'with require as bundle/require' do
     it 'imports all gems when bundler/require used' do
       doc_map_with_bundler_require = described_class.new(['bundler/require'], workspace, out: nil)
-      doc_map_with_bundler_require.cache_all!(nil)
+      doc_map_with_bundler_require.cache_doc_map_gems!(nil)
       expect(doc_map_with_bundler_require.pins.length - plain_doc_map.pins.length).to be_positive
     end
   end

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -275,7 +275,7 @@ describe Solargraph::LanguageServer::Host do
       expect(symbols).not_to be_empty
     end
 
-    it 'opens a file outside of prepared libraries' do
+    it 'opens a file outside of prepared libraries', time_limit_seconds: 120 do
       @host.prepare(File.absolute_path(File.join('spec', 'fixtures', 'workspace')))
       @host.open('file:///file.rb', 'class Foo; end', 1)
       symbols = @host.document_symbols('file:///file.rb')

--- a/spec/language_server/protocol_spec.rb
+++ b/spec/language_server/protocol_spec.rb
@@ -424,7 +424,7 @@ describe Protocol do
     expect(response['result']['available']).to be_a(String)
   end
 
-  it 'handles $/solargraph/documentGems' do
+  it 'handles $/solargraph/documentGems', time_limit_seconds: 120 do
     @protocol.request '$/solargraph/documentGems', {}
     response = @protocol.response
     expect(response['error']).to be_nil

--- a/spec/type_checker/levels/normal_spec.rb
+++ b/spec/type_checker/levels/normal_spec.rb
@@ -223,6 +223,9 @@ describe Solargraph::TypeChecker do
       # @todo This test uses kramdown-parser-gfm because it's a gem dependency known to
       #   lack typed methods. A better test wouldn't depend on the state of
       #   vendored code.
+      workspace = Solargraph::Workspace.new(Dir.pwd)
+      gemspec = Gem::Specification.find_by_name('kramdown-parser-gfm')
+      workspace.cache_gem(gemspec)
 
       checker = type_checker(%(
         require 'kramdown-parser-gfm'

--- a/spec/workspace/gemspecs_fetch_dependencies_spec.rb
+++ b/spec/workspace/gemspecs_fetch_dependencies_spec.rb
@@ -77,7 +77,7 @@ describe Solargraph::Workspace::Gemspecs, '#fetch_dependencies' do
     context 'with gem that exists in our bundle' do
       let(:gem_name) { 'undercover' }
 
-      it 'finds dependencies' do
+      it 'finds dependencies', time_limit_seconds: 120 do
         expect(deps.map(&:name)).to include('ast')
       end
     end
@@ -85,7 +85,7 @@ describe Solargraph::Workspace::Gemspecs, '#fetch_dependencies' do
     context 'with gem does not exist in our bundle' do
       let(:gem_name) { 'activerecord' }
 
-      it 'gives a useful message' do
+      it 'gives a useful message', time_limit_seconds: 120 do
         dep_names = nil
         output = capture_both { dep_names = deps.map(&:name) }
         expect(output).to include('Please install the gem activerecord')

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -145,4 +145,43 @@ describe Solargraph::Workspace do
       described_class.new('./path', config)
     end.not_to raise_error
   end
+
+  describe '#cache_all_for_workspace!' do
+    let(:pin_cache) { instance_double(Solargraph::PinCache) }
+    let(:gemspecs)  { instance_double(Solargraph::Workspace::Gemspecs) }
+
+    before do
+      allow(Solargraph::PinCache).to receive(:cache_core)
+      allow(Solargraph::PinCache).to receive(:possible_stdlibs)
+      allow(Solargraph::PinCache).to receive(:new).and_return(pin_cache)
+      allow(pin_cache).to receive_messages(cache_gem: nil, possible_stdlibs: [])
+      allow(Solargraph::PinCache).to receive(:cache_all_stdlibs)
+      allow(Solargraph::Workspace::Gemspecs).to receive(:new).and_return(gemspecs)
+      gemspec = instance_double(Gem::Specification, name: 'test_gem', version: '1.0.0')
+      allow(gemspecs).to receive(:all_gemspecs_from_bundle).and_return([gemspec])
+    end
+
+    it 'caches core pins' do
+      allow(Solargraph::PinCache).to receive_messages(core?: false)
+      allow(pin_cache).to receive_messages(cached?: true,
+                                           cache_all_stdlibs: nil)
+
+      workspace.cache_all_for_workspace!(nil, rebuild: false)
+
+      expect(Solargraph::PinCache).to have_received(:cache_core).with(out: nil)
+    end
+
+    it 'caches gems' do
+      allow(pin_cache).to receive(:cached?).and_return(false)
+
+      allow(pin_cache).to receive(:cache_all_stdlibs).with(out: nil, rebuild: false)
+
+      allow(Solargraph::PinCache).to receive_messages(core?: true,
+                                                      possible_stdlibs: [])
+
+      workspace.cache_all_for_workspace!(nil, rebuild: false)
+
+      expect(pin_cache).to have_received(:cache_gem)
+    end
+  end
 end

--- a/spec/yard_map/mapper_spec.rb
+++ b/spec/yard_map/mapper_spec.rb
@@ -7,7 +7,7 @@ describe Solargraph::YardMap::Mapper do
 
   def pins_with require
     doc_map = Solargraph::DocMap.new([require], @api_map.workspace, out: nil)
-    doc_map.cache_all!(nil)
+    doc_map.cache_doc_map_gems!(nil)
     doc_map.pins
   end
 


### PR DESCRIPTION
Replace DocMap's ad hoc gem-caching logic with delegation to PinCache
(introduced in the prior stacked PR), simplifying DocMap substantially.
Workspace gains a pin_cache accessor plus cache_gem/uncache_gem/
cache_all_for_workspace! entry points that drive PinCache for a given
workspace's gemspecs. ApiMap follows the renamed DocMap API
(cache_all! -> cache_doc_map_gems!, uncached_gemspecs.any? ->
any_uncached?) and dedupes resolved method aliases via
GemPins.combine_method_pins_by_path. Library exposes pin_cache
(delegating to workspace), uses it to check whether a gem's cache
build is already in progress, and fixes a subprocess chdir bug in its
background gem-caching thread.

Extracted from castwide/solargraph#1006 (Improve pin caching) as the
second piece of that PR, stacked on top of the PinCache engine PR.
This depends on PinCache existing; the CLI updates that depend on this
wiring follow in a further stacked PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>