### PR TITLE
Fix NoMethodError in UniqueType#to_rbs for empty generic params

### DIFF
--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -302,7 +302,6 @@ module Solargraph
         rooted_tags
       end
 
-      # @sg-ignore Need better if/elseanalysis
       # @return [String]
       def to_rbs
         if duck_type?
@@ -311,8 +310,9 @@ module Solargraph
           'bool'
         elsif name.downcase == 'nil'
           'nil'
-        elsif name == GENERIC_TAG_NAME
-          all_params.first&.name
+        elsif name == GENERIC_TAG_NAME && !all_params.empty?
+          # @sg-ignore flow sensitive typing should be able to handle !empty? narrowing first to non-nil
+          all_params.first.name
         elsif %w[Class Module].include?(name)
           rbs_name
         elsif %w[Tuple Array].include?(name) && fixed_parameters?


### PR DESCRIPTION
## Summary

`UniqueType#to_rbs`'s generic-type branch called `all_params.first&.name`,
which silently returns `nil` when a generic type has zero params instead of
falling through to the general `"#{rbs_name}#{parameters_as_rbs}"` rendering
a few lines below - the branch it should take for an unparameterized
generic. Guard on `!all_params.empty?` so that case falls through correctly.

## Test plan
- [x] `bundle exec rspec spec/complex_type_spec.rb spec/complex_type/unique_type_spec.rb`: clean
- [x] `bundle exec rubocop lib/solargraph/complex_type/unique_type.rb`: clean

Generated with [Claude Code](https://claude.com/claude-code)
