### PR TITLE
Handle root-scoped (::-prefixed) constants in is_a? narrowing

### DIFF
--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -446,6 +446,11 @@ module Solargraph
         class_node = node.children[1]
 
         return class_node.to_s if module_node.nil?
+        # e.g., ::Baz parses as s(:const, s(:cbase), :Baz) - the
+        # leading :cbase marks root-namespace resolution and isn't
+        # itself a :const node, so it needs to be recognized here
+        # rather than falling into the generic recursive case below.
+        return "::#{class_node}" if module_node.type == :cbase
 
         module_type_name = type_name(module_node)
         return unless module_type_name

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -94,6 +94,64 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.to_s).to eq('ReproBase')
   end
 
+  it 'uses is_a? in a simple if() to refine types on a root-scoped (::-prefixed) class' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      module Foo
+        class Repro < ReproBase; end
+      end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        if repr.is_a?(::Foo::Repro)
+          repr
+        else
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [8, 10])
+    expect(clip.infer.to_s).to eq('Foo::Repro')
+
+    clip = api_map.clip_at('test.rb', [10, 10])
+    expect(clip.infer.to_s).to eq('ReproBase')
+  end
+
+  it 'uses is_a? with a ::-prefixed class combined via && in a guard clause to refine types' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro < ReproBase; end
+      # @param repr [ReproBase]
+      # @return [void]
+      def verify_repro(repr)
+        return unless repr.is_a?(::Repro) && repr.respond_to?(:foo)
+        repr
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 8])
+    expect(clip.infer.to_s).to eq('Repro')
+  end
+
+  it 'uses is_a? with a ::-prefixed class in an elsif to refine types in the branch body' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      class Repro2 < ReproBase; end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        if repr.is_a?(Repro1)
+          repr
+        elsif repr.is_a?(::Repro2) && repr.respond_to?(:foo)
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [9, 10])
+    expect(clip.infer.to_s).to eq('Repro2')
+  end
+
   it 'uses is_a? in a simple unless statement to refine types' do
     source = Solargraph::Source.load_string(%(
       class ReproBase; end


### PR DESCRIPTION
## Summary
- type_name in FlowSensitiveTyping did not recognize the :cbase node that the parser gem emits for a leading :: on a constant reference (::Foo parses as s(:const, s(:cbase), :Foo)).
- Since :cbase is not a :const node, the recursive lookup in type_name fell through and returned nil for any fully-qualified constant, which silently disabled is_a?-based narrowing entirely whenever the checked class was referenced with a leading ::.
- This explains both shapes reported in the issue (guard-clause is_a?(...) && cond, and elsif is_a?(...) && cond narrowing the elsif branch body) -- both already work correctly for non-::-prefixed classes; the repro just happened to use fully-qualified names like ::Parser::AST::Node.
- Fix recognizes the :cbase child and renders it as a leading :: prefix, recursing normally otherwise.

Fixes https://github.com/apiology/solargraph/issues/1251

## Test plan
- [x] Added regression tests: is_a? on a ::-prefixed module-scoped class (bare narrowing), is_a?(::Foo) && cond in a guard clause, and is_a?(::Foo) && cond narrowing an elsif branch body -- matching the repro shapes from the issue
- [x] bundle exec rspec spec/parser/flow_sensitive_typing_spec.rb -- 48 examples, 0 failures, 1 pre-existing unrelated pending
- [x] Full bundle exec rspec -- 1621 examples, 0 failures, 65 pre-existing pending
- [x] bundle exec rubocop on changed files -- no offenses
- [x] Pre-commit hooks (RuboCop + Solargraph typecheck) pass with no new errors on modified lines