### PR TITLE
Narrow a case/when subject to the matched class in each branch

### DIFF
--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -190,6 +190,59 @@ module Solargraph
         process_expression(conditional_node, true_ranges, false_ranges)
       end
 
+      # @param case_node [Parser::AST::Node]
+      #
+      # @return [void]
+      def process_case case_node
+        return if case_node.type != :case
+
+        #
+        # See if we can narrow the subject's type inside each 'when'
+        # branch based on the classes tested for in that branch
+        #
+        # [3] pry(main)> Parser::CurrentRuby.parse("case a; when B; c; end")
+        # => s(:case,
+        #   s(:send, nil, :a),
+        #   s(:when,
+        #     s(:const, nil, :B),
+        #     s(:send, nil, :c)), nil)
+        # [4] pry(main)>
+        subject_node = case_node.children[0]
+        return if subject_node.nil?
+        # @sg-ignore Need to add nil check here
+        return unless %i[lvar ivar].include?(subject_node.type)
+
+        # @sg-ignore flow sensitive typing needs to handle attrs
+        variable_name = parse_variable(subject_node)
+        return if variable_name.nil?
+
+        # @sg-ignore Need to add nil check here
+        subject_position = Range.from_node(subject_node).start
+        pin = find_var(variable_name, subject_position)
+        return unless pin
+
+        # @sg-ignore Need to add nil check here
+        when_nodes = case_node.children[1..].compact.select { |child| child.type == :when }
+        # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
+        when_nodes.each do |when_node|
+          *value_nodes, body_node = when_node.children
+          next if body_node.nil?
+
+          type_names = value_nodes.map { |value_node| type_name(value_node) }
+          # Only narrow if every value in this 'when' clause is a
+          # simple constant reference - a splat, range, regexp, etc.
+          # isn't a type we can express as a downcast.
+          next if type_names.any?(&:nil?)
+
+          before_body_loc = body_node.location.expression.adjust(begin_pos: -1)
+          before_body_pos = Position.new(before_body_loc.line, before_body_loc.column)
+          presence = Range.new(before_body_pos, get_node_end_position(body_node))
+
+          facts = { pin => [{ type: ComplexType.parse(*type_names) }] }
+          process_facts(facts, [presence])
+        end
+      end
+
       class << self
         include Logging
       end

--- a/lib/solargraph/parser/parser_gem/node_processors.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors.rb
@@ -7,6 +7,7 @@ module Solargraph
     module ParserGem
       module NodeProcessors
         autoload :BeginNode,     'solargraph/parser/parser_gem/node_processors/begin_node'
+        autoload :CaseNode,      'solargraph/parser/parser_gem/node_processors/case_node'
         autoload :DefNode,       'solargraph/parser/parser_gem/node_processors/def_node'
         autoload :DefsNode,      'solargraph/parser/parser_gem/node_processors/defs_node'
         autoload :SendNode,      'solargraph/parser/parser_gem/node_processors/send_node'
@@ -40,6 +41,7 @@ module Solargraph
       register :kwbegin,      ParserGem::NodeProcessors::BeginNode
       register :rescue,       ParserGem::NodeProcessors::BeginNode
       register :resbody,      ParserGem::NodeProcessors::ResbodyNode
+      register :case,         ParserGem::NodeProcessors::CaseNode
       register :def,          ParserGem::NodeProcessors::DefNode
       register :defs,         ParserGem::NodeProcessors::DefsNode
       register :if,           ParserGem::NodeProcessors::IfNode

--- a/lib/solargraph/parser/parser_gem/node_processors/case_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/case_node.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Solargraph
+  module Parser
+    module ParserGem
+      module NodeProcessors
+        class CaseNode < Parser::NodeProcessor::Base
+          include ParserGem::NodeMethods
+
+          def process
+            FlowSensitiveTyping.new(locals,
+                                    ivars,
+                                    enclosing_breakable_pin,
+                                    enclosing_compound_statement_pin).process_case(node)
+            process_children
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -163,6 +163,96 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.to_s).to eq('ReproBase')
   end
 
+  it 'narrows a case/when subject to the matched class inside each branch' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      class Repro2 < ReproBase; end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        case repr
+        when Repro1
+          repr
+        when Repro2
+          repr
+        else
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [8, 10])
+    expect(clip.infer.to_s).to eq('Repro1')
+
+    clip = api_map.clip_at('test.rb', [10, 10])
+    expect(clip.infer.to_s).to eq('Repro2')
+
+    clip = api_map.clip_at('test.rb', [12, 10])
+    expect(clip.infer.to_s).to eq('ReproBase')
+  end
+
+  it 'narrows a case/when subject to a union when a when clause has multiple values' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      class Repro2 < ReproBase; end
+      class Repro3 < ReproBase; end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        case repr
+        when Repro1, Repro2
+          repr
+        when Repro3
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [9, 10])
+    expect(clip.infer.to_s).to eq('Repro1, Repro2')
+  end
+
+  it 'narrows a case/when subject to the matched class for an ivar subject' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      class Foo
+        # @param repr [ReproBase]
+        def initialize(repr)
+          @repr = repr
+        end
+
+        # @return [void]
+        def verify
+          case @repr
+          when Repro1
+            @repr
+          end
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [13, 12])
+    expect(clip.infer.to_s).to eq('Repro1')
+  end
+
+  it 'does not narrow a case/when subject when a when clause value is not a simple constant' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        case repr
+        when Repro1, some_dynamic_value
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 10])
+    expect(clip.infer.to_s).to eq('ReproBase')
+  end
+
   it 'uses is_a? in a "break unless" statement in an .each block to refine types' do
     source = Solargraph::Source.load_string(%(
       class ReproBase; end


### PR DESCRIPTION
## Summary
- case/when had no flow-sensitive-typing support at all -- there was no NodeProcessor registered for :case nodes, so a case subject kept its full original (often union) static type inside every branch, even though each when clause has already established which member type it is.
- This meant methods only present on some members of the union needed an explanatory @sg-ignore in every branch, for what is normal, idiomatic Ruby type-dispatch code (the pattern called out in the issue, e.g. the type_to_tag method in rbs_translator.rb dispatching over RBS::Types::t).
- Adds a CaseNode processor (registered for :case) that calls a new FlowSensitiveTyping#process_case, mirroring the existing is_a?/nil? narrowing machinery: it narrows the subject (a local or instance variable) to the union of the constant classes listed in each when clause, scoped to that branch body only.
- Multi-value when clauses (when A, B) narrow to a union of A and B.
- when clauses with a non-constant value (a splat, range, regexp, dynamic expression, etc.) are left unnarrowed rather than guessed at -- narrowing only applies when every value in that when clause resolves to a simple constant reference.
- This also benefits automatically from apiology/solargraph#1251 (root-scoped :: constants in type_name) once that merges, since process_case reuses the same type_name helper -- no duplicate work needed here.

Fixes apiology/solargraph#1241

## Test plan
- [x] Added regression tests: narrowing across multiple when branches (plus the else branch staying at the original type), a multi-value when clause narrowing to a union, an ivar subject, and a when clause with a non-constant value being left unnarrowed
- [x] bundle exec rspec spec/parser/flow_sensitive_typing_spec.rb -- 49 examples, 0 failures, 1 pre-existing unrelated pending
- [x] Full bundle exec rspec -- 1622 examples, 0 failures, 65 pre-existing pending
- [x] bundle exec rubocop on changed files -- no offenses
- [x] Pre-commit hooks (RuboCop + Solargraph typecheck) pass with no new errors on modified lines