### PR TITLE
Narrow x ||= value on lvars and ivars to eliminate nil

### DIFF
--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -190,6 +190,42 @@ module Solargraph
         process_expression(conditional_node, true_ranges, false_ranges)
       end
 
+      # @param or_asgn_node [Parser::AST::Node]
+      # @param presence [Range]
+      #
+      # @return [void]
+      def process_or_asgn or_asgn_node, presence
+        return if or_asgn_node.type != :or_asgn
+
+        #
+        # 'x ||= value' only actually assigns when x is falsy (nil or
+        # false), so if x was already truthy, it keeps whatever
+        # non-nil type it already had. Narrow the existing pin by
+        # excluding nil, scoped to the rest of the enclosing closure.
+        #
+        # [3] pry(main)> Parser::CurrentRuby.parse("x ||= 1")
+        # => s(:or_asgn,
+        #   s(:lvasgn, :x),
+        #   s(:int, 1))
+        # [4] pry(main)>
+        lhs = or_asgn_node.children[0]
+        # @sg-ignore Need to add nil check here
+        return unless %i[lvasgn ivasgn].include?(lhs.type)
+
+        # @sg-ignore Need to add nil check here
+        variable_name = lhs.children[0].to_s
+        # @sg-ignore Need to add nil check here
+        return if variable_name.empty?
+
+        # @sg-ignore Need to add nil check here
+        position = Range.from_node(or_asgn_node).start
+        pin = find_var(variable_name, position)
+        return unless pin
+
+        facts = { pin => [{ not_type: ComplexType::NIL }] }
+        process_facts(facts, [presence])
+      end
+
       class << self
         include Logging
       end

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -209,16 +209,18 @@ module Solargraph
         #   s(:int, 1))
         # [4] pry(main)>
         lhs = or_asgn_node.children[0]
-        # @sg-ignore Need to add nil check here
+        # @sg-ignore Parser::AST::Node#children is declared to return a bare Array, losing its element type here
         return unless %i[lvasgn ivasgn].include?(lhs.type)
 
-        # @sg-ignore Need to add nil check here
+        # @sg-ignore Parser::AST::Node#children is declared to return a bare Array, losing its element type here
         variable_name = lhs.children[0].to_s
-        # @sg-ignore Need to add nil check here
+        # @sg-ignore Parser::AST::Node#children is declared to return a bare Array, losing its element type here
         return if variable_name.empty?
 
-        # @sg-ignore Need to add nil check here
-        position = Range.from_node(or_asgn_node).start
+        range = Range.from_node(or_asgn_node)
+        return if range.nil?
+
+        position = range.start
         pin = find_var(variable_name, position)
         return unless pin
 

--- a/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
@@ -9,11 +9,13 @@ module Solargraph
 
           # @return [void]
           def process
-            here = get_node_start_position(node)
-            # @sg-ignore Need to add nil check here
-            presence = Range.new(here, region.closure.location.range.ending)
-            FlowSensitiveTyping.new(locals, ivars, enclosing_breakable_pin,
-                                    enclosing_compound_statement_pin).process_or_asgn(node, presence)
+            closure_location = region.closure.location
+            if closure_location
+              here = get_node_start_position(node)
+              presence = Range.new(here, closure_location.range.ending)
+              FlowSensitiveTyping.new(locals, ivars, enclosing_breakable_pin,
+                                      enclosing_compound_statement_pin).process_or_asgn(node, presence)
+            end
 
             new_node = node.updated(node.children[0].type, node.children[0].children + [node.children[1]])
             NodeProcessor.process(new_node, region, pins, locals, ivars)

--- a/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
@@ -5,8 +5,16 @@ module Solargraph
     module ParserGem
       module NodeProcessors
         class OrasgnNode < Parser::NodeProcessor::Base
+          include ParserGem::NodeMethods
+
           # @return [void]
           def process
+            here = get_node_start_position(node)
+            # @sg-ignore Need to add nil check here
+            presence = Range.new(here, region.closure.location.range.ending)
+            FlowSensitiveTyping.new(locals, ivars, enclosing_breakable_pin,
+                                    enclosing_compound_statement_pin).process_or_asgn(node, presence)
+
             new_node = node.updated(node.children[0].type, node.children[0].children + [node.children[1]])
             NodeProcessor.process(new_node, region, pins, locals, ivars)
           end

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -899,6 +899,50 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::Boolean')
   end
 
+  it 'narrows a plain ||= assignment on an lvar to eliminate nil' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro < ReproBase; end
+      # @param repr [Repro, nil]
+      # @return [void]
+      def verify_repro(repr)
+        repr ||= Repro.new
+        repr
+      end
+  ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 8])
+
+    pending('flow sensitive typing needs better handling of ||= on lvars')
+
+    expect(clip.infer.to_s).to eq('Repro')
+  end
+
+  it 'narrows a ||= assignment on a keyword param to eliminate nil, with no nested nil check' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [::Boolean, nil]
+        # @return [void]
+        def bar(baz: nil)
+          baz
+          baz ||= true
+          baz
+        end
+      end
+  ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [5, 10])
+    expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
+
+    clip = api_map.clip_at('test.rb', [7, 10])
+
+    pending('flow sensitive typing needs better handling of ||= on lvars')
+
+    expect(clip.infer.rooted_tags).to eq('::Boolean')
+  end
+
   it 'uses .nil? in a return if() in a try / rescue / ensure to refine types using nil checks' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -913,9 +913,6 @@ describe Solargraph::Parser::FlowSensitiveTyping do
 
     api_map = Solargraph::ApiMap.new.map(source)
     clip = api_map.clip_at('test.rb', [7, 8])
-
-    pending('flow sensitive typing needs better handling of ||= on lvars')
-
     expect(clip.infer.to_s).to eq('Repro')
   end
 
@@ -937,9 +934,6 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
 
     clip = api_map.clip_at('test.rb', [7, 10])
-
-    pending('flow sensitive typing needs better handling of ||= on lvars')
-
     expect(clip.infer.rooted_tags).to eq('::Boolean')
   end
 


### PR DESCRIPTION
## Summary
- x ||= value only actually assigns when x is falsy -- nil or false -- so if x was already truthy, it keeps whatever non-nil type it already had.
- Prior to this, OrasgnNode rewrote x ||= value as a plain x = value, discarding x prior type entirely and typing it as just the RHS value type. This pin never actually shadowed the original declared type at lookup time though, since plain reassignment pins get unioned together rather than overriding each other -- verified directly: x = A.new; x; x = B.new; x infers as A, B at the second x, not just B. That is a more general limitation shared with apiology/solargraph#1250. The variable stayed nilable after the ||= no matter what.
- Fix adds FlowSensitiveTyping#process_or_asgn, reusing the same downcast-pin machinery that already powers is_a?/nil? narrowing and is known to correctly override the base pin, unlike plain reassignment: it excludes nil from the pre-existing pin type, scoped to the rest of the enclosing closure.
- This is a conservative, scoped fix -- it does not attempt to union in the RHS value type when that type differs from the variable prior non-nil type, since that would need a proper union-typed downcast primitive and is really the same open question as #1250 for the ||= case. It covers the overwhelmingly common lazy-init pattern (x ||= SomeDefault.new, where the default matches x declared non-nil type), which accounts for the concrete real-world @sg-ignore markers this was filed against.
- Only handles :lvasgn and :ivasgn left-hand sides; other assignment targets (hash/array element writers, attr writers, etc.) keep the old behavior.
- Confirmed via typecheck that this resolves several concrete @sg-ignore markers referenced in lib/solargraph/type_checker/rules.rb todo census: lib/solargraph/type_checker.rb, lib/solargraph/bench.rb, lib/solargraph/workspace/gemspecs.rb (3 of 4 -- the 4th is a hash-index ||=, out of scope), and lib/solargraph/complex_type/unique_type.rb (though those markers are not removed in this PR, staying scoped to the flow-sensitive-typing fix itself).

## Test plan
- [x] Un-pended the two reproduction specs from the earlier commit -- both now pass
- [x] bundle exec rspec spec/parser/flow_sensitive_typing_spec.rb -- 47 examples, 0 failures, 1 pre-existing unrelated pending
- [x] Full bundle exec rspec -- 1620 examples, 0 failures, 65 pre-existing pending
- [x] bundle exec rubocop on changed files -- no offenses
- [x] Pre-commit hooks (RuboCop + Solargraph typecheck) pass with no new errors on modified lines
- [x] Verified via ad-hoc typecheck that several real @sg-ignore markers for this exact gap now report "Unneeded @sg-ignore comment"