### PR TITLE
Fix Pin::Method#== and Pin::Parameter#type_arity_decl overload bugs

### DIFF
--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -75,7 +75,7 @@ module Solargraph
 
       # @param other [Pin::Method]
       def == other
-        super && other.node == node
+        super && other.node == node && other.signatures == signatures
       end
 
       def transform_types &transform

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -95,7 +95,7 @@ module Solargraph
 
       # @return [String]
       def type_arity_decl
-        arity_decl + return_type.items.count.to_s
+        arity_decl + return_type.tags
       end
 
       def arg?


### PR DESCRIPTION
Stacked on `pin-caching-3-pincache-core` because that is what currently makes `GemPins.combine_method_pins_by_path` reachable at all - see context below.

## What this fixes

`spec/pin/method_spec.rb`'s `'combines signatures by type'` test (added by castwide/solargraph#1177, alongside the buggy `type_arity_decl` it exercises) expects `Integer#+` to combine into more than 3 signatures once `bigdecimal`'s RBS reopening of `Integer#+` is merged with core Ruby's own 4 overloads. It currently gets 1.

Two independent, pre-existing bugs, both already on `castwide/master`, unrelated to any currently open PR:

1. `Pin::Parameter#type_arity_decl` grouped overloads for merging by `return_type.items.count` (how many types are in a parameter's union) instead of the types themselves, so single-type overloads for `Integer`, `Float`, `Rational`, `Complex`, and `BigDecimal` all looked like the same bucket and had their return types unioned into each other. From castwide/solargraph#1177 (2026-05-12).

2. `Pin::Method#==` never compared `signatures` - just `node` (both nil here) plus `Pin::Base`'s own `comments`/`location` check. `bigdecimal`'s reopening reuses Ruby's own rdoc comment for `Integer#+` verbatim and neither pin sets a `location`, so two RBS declarations with completely different signatures compared as `==`. `GemPins.combine_method_pins`'s skip-if-already-identical optimization then fired and one declaration was silently dropped instead of merged. From castwide/solargraph#930 (2025-05-11).

## Why this is stacked on pin-caching-3-pincache-core

Both bugs are dormant on plain `castwide/master`: `GemPins.combine_method_pins_by_path`, the only caller that exercises this combining logic, was itself removed by castwide/solargraph#1195 ("Limit pin combination to doc maps"). This branch reintroduces that function and its call site as part of the PinCache rewiring, which is what makes these two bugs observable and testable again.

## Verification

- `spec/pin/method_spec.rb:526` ("combines signatures by type") confirmed red without this fix, green with it, on this exact base.
- Full local suite on this branch: 1646 examples, 0 failures, 65 pending.
