### PR TITLE
Narrow bare, implicit-self attr_reader-style accessor calls

### DIFF
--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -9,11 +9,16 @@ module Solargraph
       # @param ivars [Array<Solargraph::Pin::InstanceVariable>]
       # @param enclosing_breakable_pin [Solargraph::Pin::Breakable, nil]
       # @param enclosing_compound_statement_pin [Solargraph::Pin::CompoundStatement, nil]
-      def initialize locals, ivars, enclosing_breakable_pin, enclosing_compound_statement_pin
+      # @param closure [Solargraph::Pin::Closure] The pin enclosing the
+      #   code being processed (e.g. the current method), used to
+      #   resolve a bare, implicit-self call like 'steps' as a call to
+      #   a 0-arg method rather than a local variable.
+      def initialize locals, ivars, enclosing_breakable_pin, enclosing_compound_statement_pin, closure
         @locals = locals
         @ivars = ivars
         @enclosing_breakable_pin = enclosing_breakable_pin
         @enclosing_compound_statement_pin = enclosing_compound_statement_pin
+        @closure = closure
       end
 
       # @param and_node [Parser::AST::Node]
@@ -340,8 +345,10 @@ module Solargraph
       end
 
       # Finds (for a single tracked local/instance variable) or builds
-      # (for a chain of simple calls off of one, e.g. ['pin', 'location'])
-      # the pin flow-sensitive-typing facts should be recorded against.
+      # (for a chain of simple calls off of one, e.g. ['pin', 'location'],
+      # or for a bare/explicit-self 0-arg method call, e.g. ['steps'] from
+      # 'steps' or 'self.steps') the pin flow-sensitive-typing facts
+      # should be recorded against.
       #
       # A synthesized pin's type is computed lazily, from `node` itself,
       # by Pin::BaseVariable#probe the same way a real local variable's
@@ -356,8 +363,19 @@ module Solargraph
       # @param position [Position]
       # @return [Solargraph::Pin::LocalVariable, Solargraph::Pin::InstanceVariable, nil]
       def chain_pin chain_words, node, position
-        # @sg-ignore chain_words is never empty - callers already checked
-        return find_var(chain_words.first, position) if chain_words.length == 1
+        if chain_words.length == 1
+          # A bare word is ambiguous from chain_words alone -- 'steps'
+          # could be a real local variable (node.type == :lvar) or a
+          # 0-arg method call to self (node.type == :send, since the
+          # parser only emits :lvar for a name already assigned as a
+          # local in this scope). Only the former is a tracked variable.
+          # @sg-ignore chain_words is never empty - callers already checked
+          return find_var(chain_words.first, position) unless node.is_a?(::Parser::AST::Node) && node.type == :send
+
+          return unless closure
+
+          return self_call_pin(node)
+        end
 
         # @sg-ignore chain_words is never empty - callers already checked
         root_pin = find_var(chain_words.first, position)
@@ -367,6 +385,26 @@ module Solargraph
           location: Location.from_node(node),
           closure: root_pin.closure,
           name: chain_words.join('.'),
+          assignment: node,
+          source: :flow_sensitive_typing
+        )
+      end
+
+      # Builds the synthesized pin for a bare, implicit-self call to a
+      # 0-arg method, e.g. 'steps'. Rooted at `closure` rather than at a
+      # tracked variable's pin, since there is no variable to inherit a
+      # closure from. Named after the bare method word itself (not
+      # e.g. 'self.steps') so it lines up with how Chain::Call#resolve
+      # looks up a head-position call: by the call's word, via
+      # ApiMap#var_at_location.
+      #
+      # @param node [Parser::AST::Node] the call node, e.g. 'steps'
+      # @return [Solargraph::Pin::LocalVariable]
+      def self_call_pin node
+        Pin::LocalVariable.new(
+          location: Location.from_node(node),
+          closure: closure,
+          name: node.children[1].to_s,
           assignment: node,
           source: :flow_sensitive_typing
         )
@@ -501,10 +539,11 @@ module Solargraph
       end
 
       # Handles a bare truthy check on a call chain, e.g. 'pin.location'
-      # in 'return nil unless pin.location'. Bare references to a single
-      # local/instance variable are handled by #process_variable instead;
-      # this only fires once there's an explicit receiver (chain_words
-      # has more than one word).
+      # in 'return nil unless pin.location', or on a bare, implicit-self
+      # 0-arg method call, e.g. 'steps' in 'return nil unless steps'.
+      # Bare references to a single local/instance *variable* are
+      # handled by #process_variable instead (node.type would be :lvar
+      # or :ivar there, not :send, so this never double-processes them).
       #
       # @param node [Parser::AST::Node]
       # @param true_presences [Array<Range>]
@@ -518,7 +557,7 @@ module Solargraph
         return if %i[nil? !].include?(node.children[1])
 
         chain_words = parse_receiver_chain(node)
-        return if chain_words.nil? || chain_words.length < 2
+        return if chain_words.nil? || chain_words.empty?
 
         # @sg-ignore Range.from_node is nil only for a node without
         #   source location info, which doesn't happen for real parsed
@@ -576,7 +615,7 @@ module Solargraph
         %i[return raise next redo retry].include?(clause_node&.type)
       end
 
-      attr_reader :locals, :ivars, :enclosing_breakable_pin, :enclosing_compound_statement_pin
+      attr_reader :locals, :ivars, :enclosing_breakable_pin, :enclosing_compound_statement_pin, :closure
     end
   end
 end

--- a/lib/solargraph/parser/parser_gem/node_processors/and_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/and_node.rb
@@ -13,7 +13,8 @@ module Solargraph
             FlowSensitiveTyping.new(locals,
                                     ivars,
                                     enclosing_breakable_pin,
-                                    enclosing_compound_statement_pin).process_and(node)
+                                    enclosing_compound_statement_pin,
+                                    region.closure).process_and(node)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/if_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/if_node.rb
@@ -11,7 +11,8 @@ module Solargraph
             FlowSensitiveTyping.new(locals,
                                     ivars,
                                     enclosing_breakable_pin,
-                                    enclosing_compound_statement_pin).process_if(node)
+                                    enclosing_compound_statement_pin,
+                                    region.closure).process_if(node)
             condition_node = node.children[0]
             if condition_node
               pins.push Solargraph::Pin::CompoundStatement.new(

--- a/lib/solargraph/parser/parser_gem/node_processors/or_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/or_node.rb
@@ -13,7 +13,8 @@ module Solargraph
             FlowSensitiveTyping.new(locals,
                                     ivars,
                                     enclosing_breakable_pin,
-                                    enclosing_compound_statement_pin).process_or(node)
+                                    enclosing_compound_statement_pin,
+                                    region.closure).process_or(node)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/while_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/while_node.rb
@@ -11,7 +11,8 @@ module Solargraph
             FlowSensitiveTyping.new(locals,
                                     ivars,
                                     enclosing_breakable_pin,
-                                    enclosing_compound_statement_pin).process_while(node)
+                                    enclosing_compound_statement_pin,
+                                    region.closure).process_while(node)
 
             # Note - this should not be considered a block, as the
             # while statement doesn't create a closure - e.g.,

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -1075,6 +1075,40 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::String')
   end
 
+  it 'narrows a bare, implicit-self attr_reader-style accessor after a .nil? guard' do
+    source = Solargraph::Source.load_string(%(
+      class Repro
+        # @return [Array<Hash>, nil]
+        attr_reader :steps
+
+        def identify
+          return nil if steps.nil?
+          steps.empty?
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 15])
+    expect(clip.infer.rooted_tags).to eq('::Array<::Hash>')
+  end
+
+  it 'narrows a bare, implicit-self attr_reader-style accessor after a truthy guard' do
+    source = Solargraph::Source.load_string(%(
+      class Repro
+        # @return [Array<Hash>, nil]
+        attr_reader :steps
+
+        def identify
+          return nil unless steps
+          steps.empty?
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 15])
+    expect(clip.infer.rooted_tags).to eq('::Array<::Hash>')
+  end
+
   it 'narrows a repeated call to the same attr_reader-style accessor rooted in an ivar' do
     source = Solargraph::Source.load_string(%(
       class Location

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -1109,6 +1109,25 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::Array<::Hash>')
   end
 
+  it 'narrows a bare, implicit-self attr_reader-style accessor assigned into a fresh local variable' do
+    source = Solargraph::Source.load_string(%(
+      class Repro
+        # @return [Array<Hash>, nil]
+        attr_reader :steps
+
+        def identify
+          return nil if steps.nil?
+
+          local = steps
+          local.empty?
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [9, 15])
+    expect(clip.infer.rooted_tags).to eq('::Array<::Hash>')
+  end
+
   it 'narrows a repeated call to the same attr_reader-style accessor rooted in an ivar' do
     source = Solargraph::Source.load_string(%(
       class Location

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -925,5 +925,46 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it 'accepts a non-nil @type on a local assigned from a bare accessor guarded by .nil?' do
+      checker = type_checker(%(
+        class Repro
+          # @return [Array<Hash>, nil]
+          attr_reader :steps
+
+          # @return [Array<Hash>, nil]
+          def unwrap
+            return nil if steps.nil?
+
+            # @type [Array<Hash>]
+            steps_list = steps
+            steps_list.each { |step| step }
+            steps_list
+          end
+        end
+      ))
+
+      expect(checker.problems.map(&:message)).to eq([])
+    end
+
+    it 'accepts a non-nil @type on a local assigned from a bare accessor guarded by a non-nil return' do
+      checker = type_checker(%(
+        class Repro
+          # @return [Array<Hash>, nil]
+          attr_reader :substeps
+
+          # @return [Array]
+          def extract
+            return ['', nil] if substeps.nil?
+
+            # @type [Array<Hash>]
+            steps_list = substeps
+            [steps_list]
+          end
+        end
+      ))
+
+      expect(checker.problems.map(&:message)).to eq([])
+    end
   end
 end


### PR DESCRIPTION
## Summary

A nil-guard on a bare, implicit-self call (e.g. `return nil if steps.nil?`, where `steps` is an argless method like an `attr_reader`) left a later call to the same accessor (e.g. `steps.empty?`) unnarrowed — reported at https://github.com/castwide/solargraph/pull/1258#issuecomment-5199258869.

Root cause: `FlowSensitiveTyping#chain_pin`'s length-1 branch always went through `find_var`, which only matches tracked local/instance-variable pins. A bare `steps` reference is a `:send` node (method call), not `:lvar`, so lookup silently found nothing.

```ruby
class Repro
  # @return [Array<Hash>, nil]
  attr_reader :steps

  def identify
    return nil if steps.nil? # or: return nil unless steps
    steps.empty? # was: Unresolved call to empty? on Array<Hash>, nil
  end
end
```

`chain_pin` now distinguishes a length-1 chain word rooted in a real `:lvar`/`:ivar` node from one rooted in a `:send` node (a 0-arg self-call), and synthesizes a pin against the enclosing closure (now threaded into `FlowSensitiveTyping` from each node processor's `region.closure`) instead of a variable's. `process_call_chain`'s bare-truthy-guard handling is extended from chain length >= 2 to >= 1 for the same reason.

Based on `gh-fix-1249` (`castwide/solargraph#1258`) since it depends on that PR's chain-narrowing infrastructure. Once `castwide/solargraph#1258` merges, this should be retargeted at `castwide/solargraph:master` (or opened fresh there).

## Test plan
- [x] Added 2 regression specs (bare `.nil?` guard, bare truthy guard) to `spec/parser/flow_sensitive_typing_spec.rb`
- [x] `bundle exec rspec` -- 1629 examples, 0 failures
- [x] `bundle exec rubocop` on changed files -- no offenses
- [x] `bundle exec solargraph typecheck --level strong` on changed files -- 28 pre-existing problems on `gh-fix-1249` unmodified; this diff adds none (verified line-by-line)
- [x] Manually reproduced the original comment's repro and confirmed it now type-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMbuVPLPj8CjHG8EkEQjrh
