### PR TITLE
Merge #1277 (bot type) prerequisite into #1280 (duck-type own method)

### DIFF
--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -294,8 +294,7 @@ module Solargraph
         type = see_reference(api_map) || typify_from_super(api_map)
         logger.debug { "Method#typify(self=#{self}) - type=#{type&.rooted_tags.inspect}" }
         unless type.nil?
-          # @sg-ignore Need to add nil check here
-          qualified = type.qualify(api_map, *closure.gates)
+          qualified = type.qualify(api_map, *gates)
           logger.debug { "Method#typify(self=#{self}) => #{qualified.rooted_tags.inspect}" }
           return qualified
         end
@@ -611,13 +610,14 @@ module Solargraph
       end
 
       # @param api_map [ApiMap]
-      # @return [ComplexType, nil]
+      # @return [ComplexType, ComplexType::UniqueType, nil]
       def typify_from_super api_map
         stack = rest_of_stack api_map
         return nil if stack.empty?
         stack.each do |pin|
           # @sg-ignore Need to add nil check here
-          return pin.return_type unless pin.return_type.undefined?
+          next if pin.return_type.undefined?
+          return pin.typify(api_map)
         end
         nil
       end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -59,9 +59,15 @@ module Solargraph
           binder = binder.without_nil if nullable?
           # @sg-ignore Need to handle duck-typed method calls on union types
           pin_groups = binder.each_unique_type.map do |context|
-            ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
-            stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
-            [stack.first].compact
+            if context.duck_type? && context.name[1..] == word
+              # explicit: false skips arity checking; the duck type
+              # only tells us the method exists, not its signature
+              [Pin::DuckMethod.new(name: word, source: :chain, explicit: false)]
+            else
+              ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
+              stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
+              [stack.first].compact
+            end
           end
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
           pins = pin_groups.flatten.uniq(&:path)

--- a/spec/type_checker/levels/alpha_spec.rb
+++ b/spec/type_checker/levels/alpha_spec.rb
@@ -193,6 +193,19 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to eq([])
     end
 
+    it 'resolves calls to a duck type param\'s own declared method' do
+      checker = type_checker(%(
+        class Foo
+          # @param baz [#read_body]
+          # @return [void]
+          def bar(baz)
+            baz.read_body
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'resolves self correctly in arguments (second case)' do
       checker = type_checker(%(
         class Blah

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -255,6 +255,19 @@ describe Solargraph::TypeChecker do
       expect(checker.problems).to be_empty
     end
 
+    it 'resolves calls to a duck type param\'s own declared method' do
+      checker = type_checker(%(
+        class Foo
+          # @param baz [#read_body]
+          # @return [void]
+          def bar(baz)
+            baz.read_body
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'reports mismatched duck types' do
       checker = type_checker(%(
         class Foo

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -255,19 +255,6 @@ describe Solargraph::TypeChecker do
       expect(checker.problems).to be_empty
     end
 
-    it 'resolves calls to a duck type param\'s own declared method' do
-      checker = type_checker(%(
-        class Foo
-          # @param baz [#read_body]
-          # @return [void]
-          def bar(baz)
-            baz.read_body
-          end
-        end
-      ))
-      expect(checker.problems).to be_empty
-    end
-
     it 'reports mismatched duck types' do
       checker = type_checker(%(
         class Foo


### PR DESCRIPTION
Intra-fork PR to view the incremental diff and CI for PR #1280 (https://github.com/castwide/solargraph/pull/1280) after merging in PR #1277's prerequisite commit (bot type support, https://github.com/castwide/solargraph/pull/1277).

Not intended to merge upstream as-is — castwide/solargraph won't accept a base branch that only exists in a fork (see the github-cross-fork-pr-base skill). This exists purely so the incremental diff/CI for the follow-up bot? fix in Call#resolve is reviewable on its own, separate from #1277's own diff.

The real upstream PR (https://github.com/castwide/solargraph/pull/1280) is untouched, still based on castwide/solargraph:master.