### PR TITLE
Stop losing flow-typing facts, and stop flagging unreachable code as errors

### DIFF
--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -372,7 +372,19 @@ module Solargraph
       return self if exclude_types.nil?
 
       types = items - exclude_types.items
-      types = [ComplexType::UniqueType::UNDEFINED] if types.empty?
+      if types.empty?
+        # An exclusion built from more than one excluded type can
+        # result from combining independently-derived flow-sensitive
+        # facts (e.g., a `x.nil? || x.is_a?(Foo)` guard) that together
+        # happen to cover every member of the declared type. That's a
+        # sign of unreachable/defensive code, not a real type error -
+        # treat it as a no-op instead of collapsing to undefined, which
+        # would otherwise make legitimate calls in that dead code look
+        # unresolved.
+        return self if exclude_types.items.length > 1
+
+        types = [ComplexType::UniqueType::UNDEFINED]
+      end
       ComplexType.new(types)
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -373,22 +373,13 @@ module Solargraph
 
       types = items - exclude_types.items
       if types.empty?
-        # An exclusion built from more than one excluded type can
-        # result from combining independently-derived flow-sensitive
-        # facts (e.g., a `x.nil? || x.is_a?(Foo)` guard) that together
-        # happen to cover every member of the declared type. That's a
-        # sign of unreachable/defensive code, not a real type error -
-        # treat it as a no-op instead of collapsing to undefined, which
-        # would otherwise make legitimate calls in that dead code look
-        # unresolved.
-        #
-        # @todo Once #1277 lands (RBS bottom type), this could tag
-        #   `bot` instead of `undefined` for any exhausted exclusion,
-        #   not just the multi-source case, and this branch could go
-        #   away.
-        return self if exclude_types.items.length > 1
-
-        types = [ComplexType::UniqueType::UNDEFINED]
+        # An exhausted exclusion (e.g., a `x.nil? || x.is_a?(Foo)`
+        # guard that together covers every member of the declared
+        # type) means the code past this point is unreachable, not a
+        # real type error. Tag it `bot` - a subtype of every type -
+        # instead of `undefined`, so calls made on it downstream are
+        # treated as vacuously valid rather than flagged unresolved.
+        types = [ComplexType::UniqueType::BOT]
       end
       ComplexType.new(types)
     end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -381,6 +381,11 @@ module Solargraph
         # treat it as a no-op instead of collapsing to undefined, which
         # would otherwise make legitimate calls in that dead code look
         # unresolved.
+        #
+        # @todo Once #1277 lands (RBS bottom type), this could tag
+        #   `bot` instead of `undefined` for any exhausted exclusion,
+        #   not just the multi-source case, and this branch could go
+        #   away.
         return self if exclude_types.items.length > 1
 
         types = [ComplexType::UniqueType::UNDEFINED]

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -205,7 +205,21 @@ module Solargraph
       def == other
         return false unless super
         # @sg-ignore Should add type check on other
-        assignment == other.assignment
+        return false unless assignment == other.assignment
+        # combine_with results choose the earliest assignment's
+        # #location, so two combined pins covering a different number
+        # of assignments to the same variable can share #location while
+        # covering different #presence ranges - e.g. one pin combined
+        # through a variable's first reassignment, another combined
+        # through its second. Base#== doesn't compare presence, so
+        # without this check those pins looked identical to any caller
+        # keying off of #== (e.g. Array#include?).
+        # @sg-ignore Should add type check on other
+        presence == other.presence &&
+          # @sg-ignore Should add type check on other
+          intersection_return_type == other.intersection_return_type &&
+          # @sg-ignore Should add type check on other
+          exclude_return_type == other.exclude_return_type
       end
 
       def type_desc

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -203,8 +203,8 @@ module Solargraph
 
       # @param other [Object]
       def == other
+        return false unless other.is_a?(BaseVariable)
         return false unless super
-        # @sg-ignore Should add type check on other
         return false unless assignment == other.assignment
         # combine_with results choose the earliest assignment's
         # #location, so two combined pins covering a different number
@@ -214,11 +214,8 @@ module Solargraph
         # through its second. Base#== doesn't compare presence, so
         # without this check those pins looked identical to any caller
         # keying off of #== (e.g. Array#include?).
-        # @sg-ignore Should add type check on other
         presence == other.presence &&
-          # @sg-ignore Should add type check on other
           intersection_return_type == other.intersection_return_type &&
-          # @sg-ignore Should add type check on other
           exclude_return_type == other.exclude_return_type
       end
 

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -59,9 +59,23 @@ module Solargraph
           binder = binder.without_nil if nullable?
           # @sg-ignore Need to handle duck-typed method calls on union types
           pin_groups = binder.each_unique_type.map do |context|
-            ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
-            stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
-            [stack.first].compact
+            if context.bot?
+              # bot is a subtype of every type, so any method call on a
+              # bot-typed receiver is vacuously valid - the code is
+              # unreachable, so there's no real pin to resolve against,
+              # but flagging it as "unresolved" would be a false
+              # positive. A DuckMethod pin (same one used for `#read`-
+              # style duck typing) gives downstream resolution a real
+              # Pin::Method to work with - explicit: false skips arity
+              # checking - while its return type stays bot, so bot
+              # keeps propagating through the rest of the chain instead
+              # of being treated as a real value.
+              [Pin::DuckMethod.new(name: word, source: :chain, explicit: false, return_type: ComplexType::BOT)]
+            else
+              ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
+              stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
+              [stack.first].compact
+            end
           end
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
           pins = pin_groups.flatten.uniq(&:path)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -69,8 +69,13 @@ module Solargraph
               # Pin::Method to work with - explicit: false skips arity
               # checking - while its return type stays bot, so bot
               # keeps propagating through the rest of the chain instead
-              # of being treated as a real value.
-              [Pin::DuckMethod.new(name: word, source: :chain, explicit: false, return_type: ComplexType::BOT)]
+              # of being treated as a real value. closure is threaded
+              # through from name_pin since DuckMethod pins have no
+              # location of their own to derive one from - without
+              # it, Pin::Base#closure raises under strict assertions
+              # the first time anything downstream reads it.
+              [Pin::DuckMethod.new(name: word, source: :chain, explicit: false, return_type: ComplexType::BOT,
+                                   closure: name_pin.closure)]
             else
               ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
               stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)

--- a/spec/pin/base_variable_spec.rb
+++ b/spec/pin/base_variable_spec.rb
@@ -12,6 +12,37 @@ describe Solargraph::Pin::BaseVariable do
     expect(pin1).not_to eq(pin2)
   end
 
+  it 'treats combine_with results with the same location but different presence as unequal' do
+    # combine_with results choose the earliest assignment's #location,
+    # so two combine_with results over a different number of
+    # assignments to the same variable can share #location while
+    # covering different #presence ranges. Pin::Base#== only compared
+    # location, not presence, so these looked equal to any caller
+    # keying off of #== (e.g. Array#include?, used by Chain's inference
+    # recursion guard) even though they represent different sets of
+    # possible values for the variable.
+    source = Solargraph::Source.load_string(%(
+      def go(str)
+        str = str.gsub('a', 'b')
+        str = str.gsub('c', 'd')
+        str
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    smap = api_map.source_map('test.rb')
+    param = smap.locals.find { |p| p.name == 'str' && p.is_a?(Solargraph::Pin::Parameter) }
+    first_assignment = smap.locals.find { |p| p.name == 'str' && p.location.range.start.line == 2 }
+    second_assignment = smap.locals.find { |p| p.name == 'str' && p.location.range.start.line == 3 }
+
+    combined_through_first = param.combine_with(first_assignment)
+    combined_through_second = combined_through_first.combine_with(second_assignment)
+
+    expect(combined_through_first.location).to eq(combined_through_second.location)
+    expect(combined_through_first.presence).not_to eq(combined_through_second.presence)
+    expect(combined_through_first).not_to eq(combined_through_second)
+  end
+
   it 'infers types from variable assignments with unparenthesized parameters' do
     source = Solargraph::Source.load_string(%(
       class Container

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -855,6 +855,24 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to eq([])
     end
 
+    it 'resolves a call on an exhaustively-excluded (bot-typed) receiver' do
+      checker = type_checker(%(
+        class Box
+          # @return [Integer]
+          def length
+            0
+          end
+        end
+
+        # @param subs [Box]
+        # @return [void]
+        def check(subs)
+          return unless !subs.is_a?(Box) && subs.length == 2
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'interprets self references correctly' do
       checker = type_checker(%(
         class Bar

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -925,5 +925,37 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it 'resolves a repeated core-method call on a var reassigned mid-method after a reopened-class call' do
+      # https://github.com/castwide/solargraph/pull/1288#issuecomment-5273022388
+      #
+      # Not currently known to be reachable on master: it depends on
+      # flow-sensitive-typing pin combination behavior that only exists
+      # once certain in-flight branches land (as of this writing,
+      # https://github.com/castwide/solargraph/pull/1258 and
+      # https://github.com/castwide/solargraph/pull/1282 - verified
+      # neither reproduces it alone, only the two combined). Kept here
+      # as a standing regression guard so that whatever combination of
+      # future changes reintroduces the failure mode gets caught,
+      # regardless of merge order.
+      checker = type_checker(%(
+        class String
+          # @return [String]
+          def depunctuate
+            self
+          end
+        end
+
+        # @param str [String]
+        # @param other [String]
+        # @return [String]
+        def go(str, other)
+          str = str.gsub(other.depunctuate, other)
+          str = str.gsub(other, other)
+          str.gsub(other, other)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq([])
+    end
   end
 end


### PR DESCRIPTION
Two flow-typing facts about the same variable could be silently collapsed into one, losing the second.

`Pin::Base#==` compares `#location` but not `#presence`. `combine_with` gives its result the *earliest* assignment's location, so two pins covering different numbers of assignments share a location while covering different presence ranges — and every `#==` caller, `Array#include?` among them, treated them as the same pin. `BaseVariable#==` now also compares `presence`, `narrowed_return_type` and `exclude_return_type`.

Keeping both facts lets their `exclude_return_type` sets union until every member of the declared type is excluded — a guard like `x.nil? || x.is_a?(Foo)` covering everything. That means the code past it is unreachable, not mistyped, so it is now tagged `bot` (from https://github.com/castwide/solargraph/pull/1277) rather than `undefined`, and a call on a bot-typed receiver resolves to a `DuckMethod` pin returning `bot` — vacuously valid, and bot keeps propagating — instead of being flagged unresolved.

`#==` also opens with `return false unless other.is_a?(BaseVariable)`. `super` already returned false for other classes via `Pin::Base#nearly?`'s `instance_of?`; stating it explicitly removes four `@sg-ignore` suppressions.

### Test plan

- [x] `rspec` — 2 failures, both `spec/shell_spec.rb` "unbundled environments", present on castwide master `8fda63384`.
- [x] `rubocop` — count unchanged, `.rubocop_todo.yml` untouched.
- [x] CI — 27/28. `run_solargraph_rspec_specs` fails identically before this branch.

This PR was written by Claude Code on behalf of @apiology.
