### PR TITLE
Add a CompoundStatement parent chain and use it for reassignment override eligibility

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_processors/and_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/and_node.rb
@@ -12,7 +12,15 @@ module Solargraph
             # any assignment there isn't guaranteed to have executed
             lhs, rhs = node.children
             NodeProcessor.process(lhs, region, pins, locals, ivars)
-            NodeProcessor.process(rhs, region.update(conditional_boundary: Range.from_node(rhs)), pins, locals, ivars)
+            # not pushed onto `pins` - see resbody_node.rb for why
+            rhs_cs = Solargraph::Pin::CompoundStatement.new(
+              location: get_node_location(rhs),
+              closure: region.closure,
+              compound_statement: region.compound_statement,
+              node: rhs,
+              source: :parser
+            )
+            NodeProcessor.process(rhs, region.update(conditional_boundary: Range.from_node(rhs), compound_statement: rhs_cs), pins, locals, ivars)
 
             FlowSensitiveTyping.new(locals,
                                     ivars,

--- a/lib/solargraph/parser/parser_gem/node_processors/and_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/and_node.rb
@@ -20,7 +20,7 @@ module Solargraph
               node: rhs,
               source: :parser
             )
-            NodeProcessor.process(rhs, region.update(conditional_boundary: Range.from_node(rhs), compound_statement: rhs_cs), pins, locals, ivars)
+            NodeProcessor.process(rhs, region.update(compound_statement: rhs_cs, conditional: true), pins, locals, ivars)
 
             FlowSensitiveTyping.new(locals,
                                     ivars,

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -32,7 +32,7 @@ module Solargraph
             # a block's body may execute zero or multiple times (e.g.
             # Enumerable#each), so an assignment inside it is never
             # guaranteed to have executed
-            process_children region.update(closure: block_pin, conditional_boundary: Range.from_node(node), compound_statement: block_pin)
+            process_children region.update(closure: block_pin, compound_statement: block_pin, conditional: true)
           end
 
           private

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -20,6 +20,7 @@ module Solargraph
             block_pin = Solargraph::Pin::Block.new(
               location: location,
               closure: region.closure,
+              compound_statement: region.compound_statement,
               node: node,
               context: context,
               receiver: node.children[0],
@@ -31,7 +32,7 @@ module Solargraph
             # a block's body may execute zero or multiple times (e.g.
             # Enumerable#each), so an assignment inside it is never
             # guaranteed to have executed
-            process_children region.update(closure: block_pin, conditional_boundary: Range.from_node(node))
+            process_children region.update(closure: block_pin, conditional_boundary: Range.from_node(node), compound_statement: block_pin)
           end
 
           private

--- a/lib/solargraph/parser/parser_gem/node_processors/def_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/def_node.rb
@@ -52,7 +52,7 @@ module Solargraph
             else
               pins.push methpin
             end
-            process_children region.update(closure: methpin, scope: methpin.scope, compound_statement: methpin)
+            process_children region.update(closure: methpin, scope: methpin.scope, compound_statement: methpin, conditional: false)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/def_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/def_node.rb
@@ -15,6 +15,7 @@ module Solargraph
             methpin = Solargraph::Pin::Method.new(
               location: get_node_location(node),
               closure: region.closure,
+              compound_statement: region.compound_statement,
               name: name,
               context: method_context,
               comments: comments_for(node),
@@ -51,7 +52,7 @@ module Solargraph
             else
               pins.push methpin
             end
-            process_children region.update(closure: methpin, scope: methpin.scope)
+            process_children region.update(closure: methpin, scope: methpin.scope, compound_statement: methpin)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/defs_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/defs_node.rb
@@ -22,6 +22,7 @@ module Solargraph
             pins.push Solargraph::Pin::Method.new(
               location: loc,
               closure: closure,
+              compound_statement: region.compound_statement,
               name: node.children[1].to_s,
               comments: comments_for(node),
               scope: :class,
@@ -29,7 +30,7 @@ module Solargraph
               node: node,
               source: :parser
             )
-            process_children region.update(closure: pins.last, scope: :class)
+            process_children region.update(closure: pins.last, scope: :class, compound_statement: pins.last)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/defs_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/defs_node.rb
@@ -30,7 +30,7 @@ module Solargraph
               node: node,
               source: :parser
             )
-            process_children region.update(closure: pins.last, scope: :class, compound_statement: pins.last)
+            process_children region.update(closure: pins.last, scope: :class, compound_statement: pins.last, conditional: false)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/if_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/if_node.rb
@@ -35,7 +35,7 @@ module Solargraph
               )
               pins.push then_cs
               # @sg-ignore Need to add nil check here
-              NodeProcessor.process(then_node, region.update(conditional_boundary: Range.from_node(then_node), compound_statement: then_cs), pins, locals, ivars)
+              NodeProcessor.process(then_node, region.update(compound_statement: then_cs, conditional: true), pins, locals, ivars)
             end
 
             else_node = node.children[2]
@@ -50,7 +50,7 @@ module Solargraph
               )
               pins.push else_cs
               # @sg-ignore Need to add nil check here
-              NodeProcessor.process(else_node, region.update(conditional_boundary: Range.from_node(else_node), compound_statement: else_cs), pins, locals, ivars)
+              NodeProcessor.process(else_node, region.update(compound_statement: else_cs, conditional: true), pins, locals, ivars)
             end
 
             true

--- a/lib/solargraph/parser/parser_gem/node_processors/if_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/if_node.rb
@@ -17,6 +17,7 @@ module Solargraph
               pins.push Solargraph::Pin::CompoundStatement.new(
                 location: get_node_location(condition_node),
                 closure: region.closure,
+                compound_statement: region.compound_statement,
                 node: condition_node,
                 source: :parser
               )
@@ -24,26 +25,32 @@ module Solargraph
             end
             then_node = node.children[1]
             if then_node
-              pins.push Solargraph::Pin::CompoundStatement.new(
+              # @sg-ignore Need to add nil check here
+              then_cs = Solargraph::Pin::CompoundStatement.new(
                 location: get_node_location(then_node),
                 closure: region.closure,
+                compound_statement: region.compound_statement,
                 node: then_node,
                 source: :parser
               )
+              pins.push then_cs
               # @sg-ignore Need to add nil check here
-              NodeProcessor.process(then_node, region.update(conditional_boundary: Range.from_node(then_node)), pins, locals, ivars)
+              NodeProcessor.process(then_node, region.update(conditional_boundary: Range.from_node(then_node), compound_statement: then_cs), pins, locals, ivars)
             end
 
             else_node = node.children[2]
             if else_node
-              pins.push Solargraph::Pin::CompoundStatement.new(
+              # @sg-ignore Need to add nil check here
+              else_cs = Solargraph::Pin::CompoundStatement.new(
                 location: get_node_location(else_node),
                 closure: region.closure,
+                compound_statement: region.compound_statement,
                 node: else_node,
                 source: :parser
               )
+              pins.push else_cs
               # @sg-ignore Need to add nil check here
-              NodeProcessor.process(else_node, region.update(conditional_boundary: Range.from_node(else_node)), pins, locals, ivars)
+              NodeProcessor.process(else_node, region.update(conditional_boundary: Range.from_node(else_node), compound_statement: else_cs), pins, locals, ivars)
             end
 
             true

--- a/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
@@ -19,8 +19,7 @@ module Solargraph
               assignment: node.children[1],
               comments: comments_for(node),
               presence: presence,
-              definite: region.conditional_boundary.nil?,
-              conditional_override_boundary: region.conditional_boundary,
+              definite: !region.conditional,
               compound_statement: region.compound_statement,
               source: :parser
             )

--- a/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
@@ -21,6 +21,7 @@ module Solargraph
               presence: presence,
               definite: region.conditional_boundary.nil?,
               conditional_override_boundary: region.conditional_boundary,
+              compound_statement: region.compound_statement,
               source: :parser
             )
             process_children

--- a/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
@@ -37,7 +37,7 @@ module Solargraph
                 source: :parser
               )
             end
-            process_children region.update(closure: nspin, visibility: :public, compound_statement: nspin)
+            process_children region.update(closure: nspin, visibility: :public, compound_statement: nspin, conditional: false)
           end
 
           private

--- a/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
@@ -20,6 +20,7 @@ module Solargraph
               type: node.type,
               location: loc,
               closure: region.closure,
+              compound_statement: region.compound_statement,
               name: name,
               comments: comments,
               visibility: :public,
@@ -36,7 +37,7 @@ module Solargraph
                 source: :parser
               )
             end
-            process_children region.update(closure: nspin, visibility: :public)
+            process_children region.update(closure: nspin, visibility: :public, compound_statement: nspin)
           end
 
           private

--- a/lib/solargraph/parser/parser_gem/node_processors/or_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/or_node.rb
@@ -12,7 +12,15 @@ module Solargraph
             # any assignment there isn't guaranteed to have executed
             lhs, rhs = node.children
             NodeProcessor.process(lhs, region, pins, locals, ivars)
-            NodeProcessor.process(rhs, region.update(conditional_boundary: Range.from_node(rhs)), pins, locals, ivars)
+            # not pushed onto `pins` - see resbody_node.rb for why
+            rhs_cs = Solargraph::Pin::CompoundStatement.new(
+              location: get_node_location(rhs),
+              closure: region.closure,
+              compound_statement: region.compound_statement,
+              node: rhs,
+              source: :parser
+            )
+            NodeProcessor.process(rhs, region.update(conditional_boundary: Range.from_node(rhs), compound_statement: rhs_cs), pins, locals, ivars)
 
             FlowSensitiveTyping.new(locals,
                                     ivars,

--- a/lib/solargraph/parser/parser_gem/node_processors/or_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/or_node.rb
@@ -20,7 +20,7 @@ module Solargraph
               node: rhs,
               source: :parser
             )
-            NodeProcessor.process(rhs, region.update(conditional_boundary: Range.from_node(rhs), compound_statement: rhs_cs), pins, locals, ivars)
+            NodeProcessor.process(rhs, region.update(compound_statement: rhs_cs, conditional: true), pins, locals, ivars)
 
             FlowSensitiveTyping.new(locals,
                                     ivars,

--- a/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
@@ -10,7 +10,16 @@ module Solargraph
             new_node = node.updated(node.children[0].type, node.children[0].children + [node.children[1]])
             # `x ||= y` only assigns when x is falsy/undefined, so
             # it's never a guaranteed override of x's prior type
-            NodeProcessor.process(new_node, region.update(conditional_boundary: Range.from_node(node)), pins, locals, ivars)
+            #
+            # not pushed onto `pins` - see resbody_node.rb for why
+            asgn_cs = Solargraph::Pin::CompoundStatement.new(
+              location: get_node_location(node),
+              closure: region.closure,
+              compound_statement: region.compound_statement,
+              node: node,
+              source: :parser
+            )
+            NodeProcessor.process(new_node, region.update(conditional_boundary: Range.from_node(node), compound_statement: asgn_cs), pins, locals, ivars)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
@@ -19,7 +19,7 @@ module Solargraph
               node: node,
               source: :parser
             )
-            NodeProcessor.process(new_node, region.update(conditional_boundary: Range.from_node(node), compound_statement: asgn_cs), pins, locals, ivars)
+            NodeProcessor.process(new_node, region.update(compound_statement: asgn_cs, conditional: true), pins, locals, ivars)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/resbody_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/resbody_node.rb
@@ -43,7 +43,7 @@ module Solargraph
               source: :parser
             )
             # @sg-ignore Need to add nil check here
-            NodeProcessor.process(node.children[2], region.update(conditional_boundary: Range.from_node(node.children[2]), compound_statement: rescue_body_cs), pins, locals, ivars)
+            NodeProcessor.process(node.children[2], region.update(compound_statement: rescue_body_cs, conditional: true), pins, locals, ivars)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/resbody_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/resbody_node.rb
@@ -30,8 +30,20 @@ module Solargraph
                 source: :parser
               )
             end
+            # not pushed onto `pins` - and/or/orasgn/resbody bodies are
+            # too common to warrant a pin per occurrence, so only the
+            # pointer is needed for the compound_statement chain
             # @sg-ignore Need to add nil check here
-            NodeProcessor.process(node.children[2], region.update(conditional_boundary: Range.from_node(node.children[2])), pins, locals, ivars)
+            rescue_body_cs = Solargraph::Pin::CompoundStatement.new(
+              # @sg-ignore Need to add nil check here
+              location: node.children[2] ? get_node_location(node.children[2]) : nil,
+              closure: region.closure,
+              compound_statement: region.compound_statement,
+              node: node.children[2],
+              source: :parser
+            )
+            # @sg-ignore Need to add nil check here
+            NodeProcessor.process(node.children[2], region.update(conditional_boundary: Range.from_node(node.children[2]), compound_statement: rescue_body_cs), pins, locals, ivars)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/until_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/until_node.rb
@@ -22,7 +22,7 @@ module Solargraph
               source: :parser
             )
             pins.push until_pin
-            process_children region.update(conditional_boundary: Range.from_node(node), compound_statement: until_pin)
+            process_children region.update(compound_statement: until_pin, conditional: true)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/until_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/until_node.rb
@@ -13,14 +13,16 @@ module Solargraph
             # until statement doesn't create a closure - e.g.,
             # variables created inside can be seen from outside as
             # well
-            pins.push Solargraph::Pin::Until.new(
+            until_pin = Solargraph::Pin::Until.new(
               location: location,
               closure: region.closure,
+              compound_statement: region.compound_statement,
               node: node,
               comments: comments_for(node),
               source: :parser
             )
-            process_children region.update(conditional_boundary: Range.from_node(node))
+            pins.push until_pin
+            process_children region.update(conditional_boundary: Range.from_node(node), compound_statement: until_pin)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/when_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/when_node.rb
@@ -8,13 +8,15 @@ module Solargraph
           include ParserGem::NodeMethods
 
           def process
-            pins.push Solargraph::Pin::CompoundStatement.new(
+            cs = Solargraph::Pin::CompoundStatement.new(
               location: get_node_location(node),
               closure: region.closure,
+              compound_statement: region.compound_statement,
               node: node,
               source: :parser
             )
-            process_children region.update(conditional_boundary: Range.from_node(node))
+            pins.push cs
+            process_children region.update(conditional_boundary: Range.from_node(node), compound_statement: cs)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/when_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/when_node.rb
@@ -16,7 +16,7 @@ module Solargraph
               source: :parser
             )
             pins.push cs
-            process_children region.update(conditional_boundary: Range.from_node(node), compound_statement: cs)
+            process_children region.update(compound_statement: cs, conditional: true)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/while_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/while_node.rb
@@ -17,14 +17,16 @@ module Solargraph
             # while statement doesn't create a closure - e.g.,
             # variables created inside can be seen from outside as
             # well
-            pins.push Solargraph::Pin::While.new(
+            while_pin = Solargraph::Pin::While.new(
               location: location,
               closure: region.closure,
+              compound_statement: region.compound_statement,
               node: node,
               comments: comments_for(node),
               source: :parser
             )
-            process_children region.update(conditional_boundary: Range.from_node(node))
+            pins.push while_pin
+            process_children region.update(conditional_boundary: Range.from_node(node), compound_statement: while_pin)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/while_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/while_node.rb
@@ -26,7 +26,7 @@ module Solargraph
               source: :parser
             )
             pins.push while_pin
-            process_children region.update(conditional_boundary: Range.from_node(node), compound_statement: while_pin)
+            process_children region.update(compound_statement: while_pin, conditional: true)
           end
         end
       end

--- a/lib/solargraph/parser/region.rb
+++ b/lib/solargraph/parser/region.rb
@@ -21,17 +21,6 @@ module Solargraph
       # @return [Array<Symbol>]
       attr_reader :lvars
 
-      # The source range of the nearest enclosing construct that may
-      # be skipped at runtime (e.g., an if/while/until body), meaning
-      # an assignment made at the current position isn't guaranteed
-      # to have executed at a later position - except at a position
-      # that itself falls within this same range, where the
-      # assignment is still guaranteed to dominate. nil if the
-      # current position isn't inside any such construct.
-      #
-      # @return [Range, nil]
-      attr_reader :conditional_boundary
-
       # The nearest enclosing CompoundStatement pin (an if/when/while/
       # rescue/&&/||/||= body, a method/block body, or a namespace
       # body) - a series of statements/expressions where a later one
@@ -43,23 +32,36 @@ module Solargraph
       # @return [Pin::CompoundStatement]
       attr_reader :compound_statement
 
+      # True if the current position may be skipped, or run zero or
+      # multiple times, at runtime - e.g. inside an if/while/until/
+      # rescue/&&/||/||= body, or inside a block body (which, despite
+      # its Block pin being a Closure like Method/Namespace, may run
+      # zero or many times depending on the method it's passed to,
+      # unlike a method/namespace body which always runs exactly once
+      # when reached). Not derivable from `compound_statement.is_a?
+      # (Closure)` alone for that reason - Block is the case where
+      # "is a Closure" and "unconditionally executes" diverge.
+      #
+      # @return [Boolean]
+      attr_reader :conditional
+
       # @param source [Source]
       # @param closure [Pin::Closure, nil]
       # @param scope [Symbol, nil]
       # @param visibility [Symbol]
       # @param lvars [Array<Symbol>]
-      # @param conditional_boundary [Range, nil]
       # @param compound_statement [Pin::CompoundStatement, nil]
+      # @param conditional [Boolean]
       def initialize source: Solargraph::Source.load_string(''), closure: nil,
-                     scope: nil, visibility: :public, lvars: [], conditional_boundary: nil,
-                     compound_statement: nil
+                     scope: nil, visibility: :public, lvars: [],
+                     compound_statement: nil, conditional: false
         @source = source
         @closure = closure || Pin::Namespace.new(name: '', location: source.location, source: :parser)
         @compound_statement = compound_statement || @closure
         @scope = scope
         @visibility = visibility
         @lvars = lvars
-        @conditional_boundary = conditional_boundary
+        @conditional = conditional
       end
 
       # @return [String, nil]
@@ -81,19 +83,19 @@ module Solargraph
       # @param scope [Symbol, nil]
       # @param visibility [Symbol, nil]
       # @param lvars [Array<Symbol>, nil]
-      # @param conditional_boundary [Range, nil]
       # @param compound_statement [Pin::CompoundStatement, nil]
+      # @param conditional [Boolean, nil]
       # @return [Region]
-      def update closure: nil, scope: nil, visibility: nil, lvars: nil, conditional_boundary: nil,
-                 compound_statement: nil
+      def update closure: nil, scope: nil, visibility: nil, lvars: nil,
+                 compound_statement: nil, conditional: nil
         Region.new(
           source: source,
           closure: closure || self.closure,
           scope: scope || self.scope,
           visibility: visibility || self.visibility,
           lvars: lvars || self.lvars,
-          conditional_boundary: conditional_boundary || self.conditional_boundary,
-          compound_statement: compound_statement || self.compound_statement
+          compound_statement: compound_statement || self.compound_statement,
+          conditional: conditional.nil? ? self.conditional : conditional
         )
       end
 

--- a/lib/solargraph/parser/region.rb
+++ b/lib/solargraph/parser/region.rb
@@ -32,16 +32,30 @@ module Solargraph
       # @return [Range, nil]
       attr_reader :conditional_boundary
 
+      # The nearest enclosing CompoundStatement pin (an if/when/while/
+      # rescue/&&/||/||= body, a method/block body, or a namespace
+      # body) - a series of statements/expressions where a later one
+      # executing implies the earlier ones in the same series
+      # executed too. Every Closure is also a CompoundStatement, so
+      # this is a superset of the `closure` chain: it additionally
+      # includes branch bodies that aren't scopes.
+      #
+      # @return [Pin::CompoundStatement]
+      attr_reader :compound_statement
+
       # @param source [Source]
       # @param closure [Pin::Closure, nil]
       # @param scope [Symbol, nil]
       # @param visibility [Symbol]
       # @param lvars [Array<Symbol>]
       # @param conditional_boundary [Range, nil]
+      # @param compound_statement [Pin::CompoundStatement, nil]
       def initialize source: Solargraph::Source.load_string(''), closure: nil,
-                     scope: nil, visibility: :public, lvars: [], conditional_boundary: nil
+                     scope: nil, visibility: :public, lvars: [], conditional_boundary: nil,
+                     compound_statement: nil
         @source = source
         @closure = closure || Pin::Namespace.new(name: '', location: source.location, source: :parser)
+        @compound_statement = compound_statement || @closure
         @scope = scope
         @visibility = visibility
         @lvars = lvars
@@ -68,15 +82,18 @@ module Solargraph
       # @param visibility [Symbol, nil]
       # @param lvars [Array<Symbol>, nil]
       # @param conditional_boundary [Range, nil]
+      # @param compound_statement [Pin::CompoundStatement, nil]
       # @return [Region]
-      def update closure: nil, scope: nil, visibility: nil, lvars: nil, conditional_boundary: nil
+      def update closure: nil, scope: nil, visibility: nil, lvars: nil, conditional_boundary: nil,
+                 compound_statement: nil
         Region.new(
           source: source,
           closure: closure || self.closure,
           scope: scope || self.scope,
           visibility: visibility || self.visibility,
           lvars: lvars || self.lvars,
-          conditional_boundary: conditional_boundary || self.conditional_boundary
+          conditional_boundary: conditional_boundary || self.conditional_boundary,
+          compound_statement: compound_statement || self.compound_statement
         )
       end
 

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -75,6 +75,7 @@ module Solargraph
 
       # @return [Pin::Closure, nil]
       def closure
+        @closure ||= derive_closure_from_compound_statement
         unless @closure
           Solargraph.assert_or_log(:closure,
                                    "Closure not set on #{self.class} #{name.inspect} from #{source.inspect}")
@@ -730,6 +731,25 @@ module Solargraph
       attr_writer :docstring, :directives
 
       private
+
+      # Fallback for pins with no directly-assigned @closure: walk the
+      # CompoundStatement parent chain (present only on
+      # CompoundStatement-family pins - Closure, While, Until, etc.)
+      # until an ancestor is_a?(Closure). Every pin built through
+      # Region-threaded node processors already gets an explicit
+      # closure:, so this only matters for a pin constructed purely
+      # from a compound_statement chain with no closure: override.
+      #
+      # @return [Pin::Closure, nil]
+      def derive_closure_from_compound_statement
+        return nil unless is_a?(CompoundStatement)
+
+        # @sg-ignore flow sensitive typing doesn't narrow self past an is_a? guard
+        cs = compound_statement
+        # @sg-ignore flow sensitive typing doesn't narrow self past an is_a? guard
+        cs = cs.compound_statement while cs && !cs.is_a?(Closure)
+        cs
+      end
 
       # @return [void]
       def parse_comments

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -17,15 +17,10 @@ module Solargraph
       # @return [Boolean]
       attr_reader :definite
 
-      # @return [Range, nil]
-      attr_reader :conditional_override_boundary
-
       # The CompoundStatement pin this variable's (re)assignment was
       # made within - i.e. Region#compound_statement at the point of
-      # assignment. Not yet consulted by any override logic (that's
-      # conditional_override_boundary's job today); threaded through
-      # now so a future chain-walk-based override check has the data
-      # already flowing.
+      # assignment. Used by #definite_reaches? to decide whether a
+      # non-definite assignment still dominates a given reference.
       #
       # @return [Pin::CompoundStatement, nil]
       attr_reader :compound_statement
@@ -68,23 +63,17 @@ module Solargraph
       #   reassignment's type may safely override a variable's
       #   previously declared/inferred type instead of merely being
       #   unioned with it.
-      # @param conditional_override_boundary [Range, nil] When
-      #   `definite` is false because this assignment is inside a
-      #   conditional branch or loop, the source range of that
-      #   construct's body - i.e., the extent within which this
-      #   assignment, though not globally guaranteed, is still
-      #   guaranteed to dominate any reference. A reference at a
-      #   position inside this range may still treat the assignment
-      #   as an override rather than merely unioning it with earlier
-      #   possible types.
       # @param compound_statement [Pin::CompoundStatement, nil] The
       #   CompoundStatement this variable's (re)assignment was made
-      #   within.
+      #   within. When `definite` is false, a reference whose location
+      #   falls within this pin's own range may still treat the
+      #   assignment as an override rather than merely unioning it
+      #   with earlier possible types - see #definite_reaches?.
       # @param [Hash{Symbol => Object}] splat
       def initialize assignment: nil, assignments: [], mass_assignment: nil,
                      presence: nil, return_type: nil,
                      intersection_return_type: nil, exclude_return_type: nil,
-                     definite: true, conditional_override_boundary: nil,
+                     definite: true,
                      compound_statement: nil,
                      **splat
         super(**splat)
@@ -96,7 +85,6 @@ module Solargraph
         @exclude_return_type = exclude_return_type
         @presence = presence
         @definite = definite
-        @conditional_override_boundary = conditional_override_boundary
         @compound_statement = compound_statement
       end
 
@@ -127,7 +115,7 @@ module Solargraph
       # @param location [Location, nil] The position being resolved,
       #   if known - used to decide whether a not-globally-definite
       #   `other` should still override us because the position falls
-      #   within `other`'s conditional_override_boundary.
+      #   within `other`'s compound_statement.
       def combine_with other, attrs = {}, location: nil
         new_assignments = combine_assignments(other, location)
         new_attrs = attrs.merge({
@@ -402,7 +390,7 @@ module Solargraph
       # @param other [self]
       # @param location [Location, nil] The position being resolved,
       #   if known - lets a conditional `other` still override us when
-      #   `location` falls inside `other`'s conditional_override_boundary.
+      #   `location` falls within `other`'s compound_statement.
       # @return [Boolean]
       def override_assignments? other, location = nil
         (other.definite || other.definite_reaches?(location)) && other.closure == closure &&
@@ -413,18 +401,24 @@ module Solargraph
 
       # True if this pin's assignment, though not globally definite,
       # is still guaranteed to dominate `location` - i.e., `location`
-      # falls inside the conditional construct's body that this
-      # assignment was made in, so no earlier branch exit could have
-      # skipped it by the time `location` is reached.
+      # falls within the CompoundStatement body (an if/while/until/
+      # rescue/&&/||/||= branch) this assignment was made in, so no
+      # earlier branch exit could have skipped it by the time
+      # `location` is reached. A nested CompoundStatement's location
+      # is always a subrange of its parent's, so this single
+      # containment check already accounts for arbitrarily nested
+      # branches without walking the compound_statement chain further.
       #
       # @param location [Location, nil]
       # @return [Boolean]
       def definite_reaches? location
-        boundary = conditional_override_boundary
-        return false unless location && boundary
+        cs = compound_statement
+        return false unless location && cs&.location&.range
 
-        location.filename == self.location&.filename &&
-          boundary.contain?(location.range.start)
+        # @sg-ignore flow sensitive typing needs to handle attrs
+        cs.location.filename == location.filename &&
+          # @sg-ignore flow sensitive typing needs to handle attrs
+          cs.location.range.contain?(location.range.start)
       end
 
       private

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -20,6 +20,16 @@ module Solargraph
       # @return [Range, nil]
       attr_reader :conditional_override_boundary
 
+      # The CompoundStatement pin this variable's (re)assignment was
+      # made within - i.e. Region#compound_statement at the point of
+      # assignment. Not yet consulted by any override logic (that's
+      # conditional_override_boundary's job today); threaded through
+      # now so a future chain-walk-based override check has the data
+      # already flowing.
+      #
+      # @return [Pin::CompoundStatement, nil]
+      attr_reader :compound_statement
+
       # @param return_type [ComplexType, nil]
       # @param assignment [Parser::AST::Node, nil] First assignment
       #   that was made to this variable
@@ -67,11 +77,15 @@ module Solargraph
       #   position inside this range may still treat the assignment
       #   as an override rather than merely unioning it with earlier
       #   possible types.
+      # @param compound_statement [Pin::CompoundStatement, nil] The
+      #   CompoundStatement this variable's (re)assignment was made
+      #   within.
       # @param [Hash{Symbol => Object}] splat
       def initialize assignment: nil, assignments: [], mass_assignment: nil,
                      presence: nil, return_type: nil,
                      intersection_return_type: nil, exclude_return_type: nil,
                      definite: true, conditional_override_boundary: nil,
+                     compound_statement: nil,
                      **splat
         super(**splat)
         @assignments = (assignment.nil? ? [] : [assignment]) + assignments
@@ -83,6 +97,7 @@ module Solargraph
         @presence = presence
         @definite = definite
         @conditional_override_boundary = conditional_override_boundary
+        @compound_statement = compound_statement
       end
 
       # @param presence [Range]

--- a/lib/solargraph/pin/compound_statement.rb
+++ b/lib/solargraph/pin/compound_statement.rb
@@ -44,11 +44,54 @@ module Solargraph
     class CompoundStatement < Pin::Base
       attr_reader :node
 
+      # The immediately enclosing CompoundStatement, if any - nil only
+      # for the synthetic root Namespace Region creates for top-level
+      # code. Since Closure < CompoundStatement, walking this chain
+      # until an ancestor is_a?(Closure) is how Base#closure is
+      # derived when a pin has no directly-assigned @closure.
+      #
+      # @return [Pin::CompoundStatement, nil]
+      attr_reader :compound_statement
+
       # @param node [Parser::AST::Node, nil]
+      # @param compound_statement [Pin::CompoundStatement, nil]
       # @param [Hash{Symbol => Object}] splat
-      def initialize node: nil, **splat
+      def initialize node: nil, compound_statement: nil, **splat
         super(**splat)
         @node = node
+        @compound_statement = compound_statement
+      end
+
+      # @param other [self]
+      # @param attrs [Hash{Symbol => Object}]
+      # @return [self]
+      def combine_with other, attrs = {}
+        new_attrs = { compound_statement: combine_compound_statement(other) }.merge(attrs)
+        super(other, new_attrs)
+      end
+
+      # Bare CompoundStatement pins (if/when/rescue/&&/||/||= bodies)
+      # all share name == '', so the same-name-assertion in
+      # Base#choose_pin_attr_with_same_name (used by #combine_closure)
+      # would be meaningless noise here - pick by location instead,
+      # mirroring BaseVariable#combine_closure.
+      #
+      # @param other [self]
+      # @return [Pin::CompoundStatement, nil]
+      def combine_compound_statement other
+        return compound_statement if compound_statement == other.compound_statement
+        return compound_statement || other.compound_statement if compound_statement.nil? || other.compound_statement.nil?
+
+        # @sg-ignore flow sensitive typing needs to handle attrs
+        if compound_statement.location.nil? || other.compound_statement.location.nil?
+          # @sg-ignore flow sensitive typing needs to handle attrs
+          return compound_statement.location.nil? ? other.compound_statement : compound_statement
+        end
+
+        # @sg-ignore flow sensitive typing needs to handle attrs
+        return compound_statement if compound_statement.location <= other.compound_statement.location
+
+        other.compound_statement
       end
     end
   end

--- a/spec/pin/compound_statement_spec.rb
+++ b/spec/pin/compound_statement_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe Solargraph::Pin::CompoundStatement do
+  # Every pin built through Region-threaded node processors still gets
+  # an explicit `closure:`, so `Pin::Base#closure` returns the stored
+  # value, not the derived one - the derivation only kicks in as a
+  # fallback. These specs check the two would agree anyway, so a
+  # future node processor that updates one threading (closure: or
+  # compound_statement:) without the other gets caught here instead
+  # of silently drifting.
+  def derive_closure pin
+    cs = pin.compound_statement
+    cs = cs.compound_statement while cs && !cs.is_a?(Solargraph::Pin::Closure)
+    cs
+  end
+
+  it 'agrees with the stored closure for compound statements nested in a method, if, and while' do
+    source_map = Solargraph::SourceMap.load_string(%(
+      class Foo
+        def bar(flag)
+          if flag
+            while flag
+              local = 1
+            end
+          end
+        end
+      end
+    ))
+
+    compound_statement_pins = source_map.pins.select { |pin| pin.is_a?(described_class) }
+    expect(compound_statement_pins).not_to be_empty
+
+    compound_statement_pins.each do |pin|
+      expect(derive_closure(pin)).to eq(pin.closure), "mismatch for #{pin.inspect}"
+    end
+  end
+
+  it 'agrees with the stored closure for compound statements nested in a block' do
+    source_map = Solargraph::SourceMap.load_string(%(
+      class Foo
+        def bar
+          [1].each do |i|
+            if i
+              local = i
+            end
+          end
+        end
+      end
+    ))
+
+    compound_statement_pins = source_map.pins.select { |pin| pin.is_a?(described_class) }
+    expect(compound_statement_pins).not_to be_empty
+
+    compound_statement_pins.each do |pin|
+      expect(derive_closure(pin)).to eq(pin.closure), "mismatch for #{pin.inspect}"
+    end
+  end
+
+  it 'derives the enclosing method as closure for a bare CompoundStatement built only with compound_statement:' do
+    source_map = Solargraph::SourceMap.load_string(%(
+      class Foo
+        def bar
+          1
+        end
+      end
+    ))
+    method_pin = source_map.pins.find { |pin| pin.is_a?(Solargraph::Pin::Method) && pin.name == 'bar' }
+
+    bare_pin = described_class.new(
+      location: method_pin.location,
+      compound_statement: method_pin,
+      source: :parser
+    )
+
+    expect(bare_pin.closure).to eq(method_pin)
+  end
+end

--- a/spec/pin/compound_statement_spec.rb
+++ b/spec/pin/compound_statement_spec.rb
@@ -74,4 +74,28 @@ describe Solargraph::Pin::CompoundStatement do
 
     expect(bare_pin.closure).to eq(method_pin)
   end
+
+  describe '#combine_with' do
+    let(:earlier_location) { Solargraph::Location.new('test.rb', Solargraph::Range.from_to(1, 0, 3, 0)) }
+    let(:later_location) { Solargraph::Location.new('test.rb', Solargraph::Range.from_to(5, 0, 7, 0)) }
+
+    it 'prefers the compound_statement with the earlier location' do
+      earlier_cs = described_class.new(location: earlier_location, source: :parser)
+      later_cs = described_class.new(location: later_location, source: :parser)
+      pin1 = described_class.new(location: earlier_location, compound_statement: earlier_cs, source: :parser)
+      pin2 = described_class.new(location: later_location, compound_statement: later_cs, source: :parser)
+
+      expect(pin1.combine_with(pin2).compound_statement).to eq(earlier_cs)
+      expect(pin2.combine_with(pin1).compound_statement).to eq(earlier_cs)
+    end
+
+    it 'prefers a non-nil compound_statement over a nil one' do
+      cs = described_class.new(location: earlier_location, source: :parser)
+      pin1 = described_class.new(location: earlier_location, compound_statement: nil, source: :parser)
+      pin2 = described_class.new(location: earlier_location, compound_statement: cs, source: :parser)
+
+      expect(pin1.combine_with(pin2).compound_statement).to eq(cs)
+      expect(pin2.combine_with(pin1).compound_statement).to eq(cs)
+    end
+  end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -956,6 +956,23 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to eq([])
     end
 
+    it 'does not let a loop-body reassignment override a reference textually before it' do
+      checker = type_checker(%(
+        # @param str [String]
+        # @param num [Integer]
+        # @param flag [Boolean]
+        # @return [void]
+        def loop_reassign(str, num, flag)
+          local = num
+          while flag
+            local.abs
+            local = str
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq([])
+    end
+
     it 'updates a local variable type after reassignment to a different literal type' do
       checker = type_checker(%(
         # @return [void]


### PR DESCRIPTION
Follow-up to https://github.com/castwide/solargraph/pull/1282, stacked on its head branch. Design and rationale discussed at https://github.com/castwide/solargraph/pull/1282#issuecomment-5295201688 and follow-up conversation.

## Summary

PR 1282 fixed a bug where a type-changing reassignment inside a conditional branch didn't override the earlier assignment's type even at a use site inside the same branch, right after the reassignment. That fix worked but duplicated structure the codebase already partially has: `Pin::CompoundStatement` ("a series of statements where if a later one executes, all earlier ones did too") and `Pin::Closure < CompoundStatement` ("a CompoundStatement that is also a scope"). This PR removes that duplication.

- `Region#compound_statement`: the nearest enclosing `CompoundStatement` pin, threaded through `Region#update` the same way `closure` already is - every construct that creates a `CompoundStatement`-family pin (or previously had no corresponding pin at all - `and`/`or`/`orasgn`/rescue bodies) now sets this pointer.
- `Pin::Base#closure` becomes `@closure || <derived from the compound_statement chain>`, strictly as a fallback behind the stored value - no behavior change, since every pin built through Region-threaded node processors still passes `closure:` explicitly.
- `BaseVariable#definite_reaches?` no longer compares a query `Location` against a separately-computed `conditional_override_boundary` Range. It now checks containment directly against the `compound_statement` pin's own `location.range` - the same range, read once instead of computed twice. `Region#conditional_boundary`, `BaseVariable#conditional_override_boundary`, and the `Range.from_node(...)` call in every conditional node processor are gone.
- `Region#conditional` (a plain boolean) replaces the old `conditional_boundary.nil?` check for computing `definite` - kept separate from the `compound_statement` chain because a block body pin is a `Closure` (for scoping) but still runs zero-or-many times, which `conditional`/`compound_statement.is_a?(Closure)` would conflate if collapsed into one signal.
- New specs: an agreement check that the derived `closure` matches the stored one across nested if/while/block structures (caught a real threading gap before it shipped), a loop-ordering regression (a while-body reassignment must not affect a reference textually before it), and `combine_with` coverage for `Pin::CompoundStatement`.

## Test plan
- [x] `bundle exec rspec spec/` - 1638 examples, 0 failures
- [x] `bundle exec solargraph typecheck --level strong` - diffed against the pre-1282-follow-up baseline: 587 problems vs. 591 baseline (net fewer - deleting the old Range computation also removed several instances of the pre-existing nilable-AST-child pattern already tolerated throughout these files)
- [x] `bundle exec rubocop` - clean on touched files
- [x] Original bug repro from PR 1282's review comment re-verified via the strong_spec.rb regression test added there

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>