### PR TITLE
Move conditional from Region to the CompoundStatement pin itself

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_processors/and_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/and_node.rb
@@ -17,10 +17,11 @@ module Solargraph
               location: get_node_location(rhs),
               closure: region.closure,
               compound_statement: region.compound_statement,
+              conditional: true,
               node: rhs,
               source: :parser
             )
-            NodeProcessor.process(rhs, region.update(compound_statement: rhs_cs, conditional: true), pins, locals, ivars)
+            NodeProcessor.process(rhs, region.update(compound_statement: rhs_cs), pins, locals, ivars)
 
             FlowSensitiveTyping.new(locals,
                                     ivars,

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -21,6 +21,10 @@ module Solargraph
               location: location,
               closure: region.closure,
               compound_statement: region.compound_statement,
+              # a block's body may execute zero or multiple times (e.g.
+              # Enumerable#each), so an assignment inside it is never
+              # guaranteed to have executed
+              conditional: true,
               node: node,
               context: context,
               receiver: node.children[0],
@@ -29,10 +33,7 @@ module Solargraph
               source: :parser
             )
             pins.push block_pin
-            # a block's body may execute zero or multiple times (e.g.
-            # Enumerable#each), so an assignment inside it is never
-            # guaranteed to have executed
-            process_children region.update(closure: block_pin, compound_statement: block_pin, conditional: true)
+            process_children region.update(closure: block_pin, compound_statement: block_pin)
           end
 
           private

--- a/lib/solargraph/parser/parser_gem/node_processors/def_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/def_node.rb
@@ -52,7 +52,7 @@ module Solargraph
             else
               pins.push methpin
             end
-            process_children region.update(closure: methpin, scope: methpin.scope, compound_statement: methpin, conditional: false)
+            process_children region.update(closure: methpin, scope: methpin.scope, compound_statement: methpin)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/defs_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/defs_node.rb
@@ -30,7 +30,7 @@ module Solargraph
               node: node,
               source: :parser
             )
-            process_children region.update(closure: pins.last, scope: :class, compound_statement: pins.last, conditional: false)
+            process_children region.update(closure: pins.last, scope: :class, compound_statement: pins.last)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/if_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/if_node.rb
@@ -30,12 +30,13 @@ module Solargraph
                 location: get_node_location(then_node),
                 closure: region.closure,
                 compound_statement: region.compound_statement,
+                conditional: true,
                 node: then_node,
                 source: :parser
               )
               pins.push then_cs
               # @sg-ignore Need to add nil check here
-              NodeProcessor.process(then_node, region.update(compound_statement: then_cs, conditional: true), pins, locals, ivars)
+              NodeProcessor.process(then_node, region.update(compound_statement: then_cs), pins, locals, ivars)
             end
 
             else_node = node.children[2]
@@ -45,12 +46,13 @@ module Solargraph
                 location: get_node_location(else_node),
                 closure: region.closure,
                 compound_statement: region.compound_statement,
+                conditional: true,
                 node: else_node,
                 source: :parser
               )
               pins.push else_cs
               # @sg-ignore Need to add nil check here
-              NodeProcessor.process(else_node, region.update(compound_statement: else_cs, conditional: true), pins, locals, ivars)
+              NodeProcessor.process(else_node, region.update(compound_statement: else_cs), pins, locals, ivars)
             end
 
             true

--- a/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
@@ -19,7 +19,7 @@ module Solargraph
               assignment: node.children[1],
               comments: comments_for(node),
               presence: presence,
-              definite: !region.conditional,
+              definite: !region.compound_statement.conditional,
               compound_statement: region.compound_statement,
               source: :parser
             )

--- a/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
@@ -37,7 +37,7 @@ module Solargraph
                 source: :parser
               )
             end
-            process_children region.update(closure: nspin, visibility: :public, compound_statement: nspin, conditional: false)
+            process_children region.update(closure: nspin, visibility: :public, compound_statement: nspin)
           end
 
           private

--- a/lib/solargraph/parser/parser_gem/node_processors/or_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/or_node.rb
@@ -17,10 +17,11 @@ module Solargraph
               location: get_node_location(rhs),
               closure: region.closure,
               compound_statement: region.compound_statement,
+              conditional: true,
               node: rhs,
               source: :parser
             )
-            NodeProcessor.process(rhs, region.update(compound_statement: rhs_cs, conditional: true), pins, locals, ivars)
+            NodeProcessor.process(rhs, region.update(compound_statement: rhs_cs), pins, locals, ivars)
 
             FlowSensitiveTyping.new(locals,
                                     ivars,

--- a/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
@@ -16,10 +16,11 @@ module Solargraph
               location: get_node_location(node),
               closure: region.closure,
               compound_statement: region.compound_statement,
+              conditional: true,
               node: node,
               source: :parser
             )
-            NodeProcessor.process(new_node, region.update(compound_statement: asgn_cs, conditional: true), pins, locals, ivars)
+            NodeProcessor.process(new_node, region.update(compound_statement: asgn_cs), pins, locals, ivars)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/resbody_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/resbody_node.rb
@@ -39,11 +39,12 @@ module Solargraph
               location: node.children[2] ? get_node_location(node.children[2]) : nil,
               closure: region.closure,
               compound_statement: region.compound_statement,
+              conditional: true,
               node: node.children[2],
               source: :parser
             )
             # @sg-ignore Need to add nil check here
-            NodeProcessor.process(node.children[2], region.update(compound_statement: rescue_body_cs, conditional: true), pins, locals, ivars)
+            NodeProcessor.process(node.children[2], region.update(compound_statement: rescue_body_cs), pins, locals, ivars)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/until_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/until_node.rb
@@ -17,12 +17,13 @@ module Solargraph
               location: location,
               closure: region.closure,
               compound_statement: region.compound_statement,
+              conditional: true,
               node: node,
               comments: comments_for(node),
               source: :parser
             )
             pins.push until_pin
-            process_children region.update(compound_statement: until_pin, conditional: true)
+            process_children region.update(compound_statement: until_pin)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/when_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/when_node.rb
@@ -12,11 +12,12 @@ module Solargraph
               location: get_node_location(node),
               closure: region.closure,
               compound_statement: region.compound_statement,
+              conditional: true,
               node: node,
               source: :parser
             )
             pins.push cs
-            process_children region.update(compound_statement: cs, conditional: true)
+            process_children region.update(compound_statement: cs)
           end
         end
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/while_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/while_node.rb
@@ -21,12 +21,13 @@ module Solargraph
               location: location,
               closure: region.closure,
               compound_statement: region.compound_statement,
+              conditional: true,
               node: node,
               comments: comments_for(node),
               source: :parser
             )
             pins.push while_pin
-            process_children region.update(compound_statement: while_pin, conditional: true)
+            process_children region.update(compound_statement: while_pin)
           end
         end
       end

--- a/lib/solargraph/parser/region.rb
+++ b/lib/solargraph/parser/region.rb
@@ -32,36 +32,21 @@ module Solargraph
       # @return [Pin::CompoundStatement]
       attr_reader :compound_statement
 
-      # True if the current position may be skipped, or run zero or
-      # multiple times, at runtime - e.g. inside an if/while/until/
-      # rescue/&&/||/||= body, or inside a block body (which, despite
-      # its Block pin being a Closure like Method/Namespace, may run
-      # zero or many times depending on the method it's passed to,
-      # unlike a method/namespace body which always runs exactly once
-      # when reached). Not derivable from `compound_statement.is_a?
-      # (Closure)` alone for that reason - Block is the case where
-      # "is a Closure" and "unconditionally executes" diverge.
-      #
-      # @return [Boolean]
-      attr_reader :conditional
-
       # @param source [Source]
       # @param closure [Pin::Closure, nil]
       # @param scope [Symbol, nil]
       # @param visibility [Symbol]
       # @param lvars [Array<Symbol>]
       # @param compound_statement [Pin::CompoundStatement, nil]
-      # @param conditional [Boolean]
       def initialize source: Solargraph::Source.load_string(''), closure: nil,
                      scope: nil, visibility: :public, lvars: [],
-                     compound_statement: nil, conditional: false
+                     compound_statement: nil
         @source = source
         @closure = closure || Pin::Namespace.new(name: '', location: source.location, source: :parser)
         @compound_statement = compound_statement || @closure
         @scope = scope
         @visibility = visibility
         @lvars = lvars
-        @conditional = conditional
       end
 
       # @return [String, nil]
@@ -84,18 +69,16 @@ module Solargraph
       # @param visibility [Symbol, nil]
       # @param lvars [Array<Symbol>, nil]
       # @param compound_statement [Pin::CompoundStatement, nil]
-      # @param conditional [Boolean, nil]
       # @return [Region]
       def update closure: nil, scope: nil, visibility: nil, lvars: nil,
-                 compound_statement: nil, conditional: nil
+                 compound_statement: nil
         Region.new(
           source: source,
           closure: closure || self.closure,
           scope: scope || self.scope,
           visibility: visibility || self.visibility,
           lvars: lvars || self.lvars,
-          compound_statement: compound_statement || self.compound_statement,
-          conditional: conditional.nil? ? self.conditional : conditional
+          compound_statement: compound_statement || self.compound_statement
         )
       end
 

--- a/lib/solargraph/pin/compound_statement.rb
+++ b/lib/solargraph/pin/compound_statement.rb
@@ -53,20 +53,37 @@ module Solargraph
       # @return [Pin::CompoundStatement, nil]
       attr_reader :compound_statement
 
+      # True if this construct's body may be skipped, or run zero or
+      # multiple times, at runtime - e.g. an if/while/until/rescue/&&/
+      # ||/||= body, or a block body (which, despite being a Closure
+      # like Method/Namespace, may run zero or many times depending on
+      # the method it's passed to, unlike a method/namespace body,
+      # which always runs exactly once when reached). Defaults false -
+      # true only where a node processor explicitly marks a construct
+      # as conditionally executed.
+      #
+      # @return [Boolean]
+      attr_reader :conditional
+
       # @param node [Parser::AST::Node, nil]
       # @param compound_statement [Pin::CompoundStatement, nil]
+      # @param conditional [Boolean]
       # @param [Hash{Symbol => Object}] splat
-      def initialize node: nil, compound_statement: nil, **splat
+      def initialize node: nil, compound_statement: nil, conditional: false, **splat
         super(**splat)
         @node = node
         @compound_statement = compound_statement
+        @conditional = conditional
       end
 
       # @param other [self]
       # @param attrs [Hash{Symbol => Object}]
       # @return [self]
       def combine_with other, attrs = {}
-        new_attrs = { compound_statement: combine_compound_statement(other) }.merge(attrs)
+        new_attrs = {
+          compound_statement: combine_compound_statement(other),
+          conditional: choose(other, :conditional)
+        }.merge(attrs)
         super(other, new_attrs)
       end
 


### PR DESCRIPTION
Follow-up to https://github.com/castwide/solargraph/pull/1282 (via https://github.com/apiology/solargraph/pull/57), stacked on the same head branch.

## Summary

`Region#conditional` was a separate boolean threaded alongside `compound_statement`, requiring every node processor to pass both in lockstep (e.g. `block_node.rb`: `compound_statement: block_pin, conditional: true`). Keeping two parallel values in sync at every call site is exactly the kind of duplication #57 set out to remove, and it's the shape of bug that broke Block handling mid-refactor there (`definite` was briefly, incorrectly, derived from `compound_statement.is_a?(Closure)`, which is true for `Block` despite a block body running zero or many times).

`conditional` is now a constructor attribute on `Pin::CompoundStatement` itself, set once where each construct is built (`Pin::Block.new(..., conditional: true)`, `Pin::Method.new(...)` defaulting `false`), so there's only one thing to get right per site instead of two.

It can't be a class-level constant: the bare `Pin::CompoundStatement` class is used both for an `if`'s own condition (never conditional) and for then/else/rhs/rescue bodies (always conditional) - same class, different instances, different answers - so it stays an instance attribute, same as `closure:`/`compound_statement:` already are.

`lvasgn_node.rb`'s `definite` computation becomes a single-hop read: `!region.compound_statement.conditional`, no separate `Region` field. `Pin::CompoundStatement#combine_with` merges the new attribute via `choose`, since two versions of the same construct should already agree on it.

## Test plan
- [x] `bundle exec rspec spec/` - 1638 examples, 0 failures
- [x] `bundle exec solargraph typecheck --level strong` - diffed clean against the prior baseline (587 problems, unchanged)
- [x] `bundle exec rubocop` - clean on touched files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
