### PR TITLE
[DO NOT MERGE] Infer through Class#new for unparameterized and generic Class receivers

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -470,7 +470,19 @@ module Solargraph
         result.concat inner_get_methods('Kernel', :instance, visibility, deep, skip)
       else
         result.concat inner_get_methods(rooted_tag, scope, visibility, deep, skip)
-        unless %w[Class Class<Class>].include?(rooted_tag)
+        if %w[Class Class<Class>].include?(rooted_tag)
+          # RBS declares Class#new as untyped because it cannot
+          # parameterize Class. We know more: Class.new returns a new
+          # class whose instances are (at least) Objects, and calling
+          # .new on an unparameterized Class-typed receiver returns
+          # some instance of it - an Object.
+          result.map! do |pin|
+            next pin unless pin.path == 'Class#new'
+
+            return_tag = scope == :class ? 'Class<Object>' : 'Object'
+            pin.proxy_with_signatures ComplexType.try_parse(return_tag)
+          end
+        else
           result.map! do |pin|
             next pin unless pin.path == 'Class#new'
             init_pin = get_method_stack(rooted_tag, 'initialize').first

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -483,6 +483,28 @@ module Solargraph
             pin.proxy_with_signatures ComplexType.try_parse(return_tag)
           end
         else
+          if scope == :class && rooted_type.name == ComplexType::GENERIC_TAG_NAME
+            # A Class<generic<T>> receiver: the namespace lookup on the
+            # unresolved generic finds no singleton methods (there is no
+            # 'generic' namespace), so no Class#new pin ever appears and
+            # .new goes undefined. The instance type is knowable, though -
+            # it is the generic itself, which the caller binds. Synthesize
+            # a permissive new pin that keeps it symbolic; argument
+            # checking stays lenient because the real initializer is
+            # unknown here.
+            generic_new = Pin::Method.new(
+              name: 'new',
+              scope: :class,
+              return_type: rooted_type,
+              closure: Pin::Namespace.new(name: 'Class', source: :api_map),
+              source: :api_map
+            )
+            generic_new.parameters = [
+              Pin::Parameter.new(decl: :restarg, name: 'args', closure: generic_new, source: :api_map),
+              Pin::Parameter.new(decl: :kwrestarg, name: 'kwargs', closure: generic_new, source: :api_map)
+            ].freeze
+            result.push generic_new
+          end
           result.map! do |pin|
             next pin unless pin.path == 'Class#new'
             init_pin = get_method_stack(rooted_tag, 'initialize').first

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -822,7 +822,7 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.infer.tag).to eq('Class')
   end
 
-  it 'infers undefined from Class#new' do
+  it 'infers Object from .new on an unparameterized Class' do
     source = Solargraph::Source.load_string(%(
       cls = Class.new
       cls.new
@@ -830,17 +830,28 @@ describe Solargraph::SourceMap::Clip do
     api_map = Solargraph::ApiMap.new
     api_map.map source
     clip = api_map.clip_at('test.rb', [2, 11])
-    expect(clip.infer.tag).to eq('undefined')
+    expect(clip.infer.tag).to eq('Object')
   end
 
-  it 'infers undefined from Class.new.new' do
+  it 'infers Object from Class.new.new' do
     source = Solargraph::Source.load_string(%(
       Class.new.new
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
     api_map.map source
     clip = api_map.clip_at('test.rb', [1, 17])
-    expect(clip.infer.tag).to eq('undefined')
+    expect(clip.infer.tag).to eq('Object')
+  end
+
+  it 'still infers Class for a variable assigned from Class.new' do
+    source = Solargraph::Source.load_string(%(
+      cls = Class.new
+      cls
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [2, 7])
+    expect(clip.infer.tag).to eq('Class')
   end
 
   it 'completes class instance variables in the namespace' do

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -854,6 +854,37 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.infer.tag).to eq('Class')
   end
 
+  it 'infers the symbolic generic from Class<generic<T>>#new' do
+    source = Solargraph::Source.load_string(%(
+      # @generic T
+      # @param clazz [Class<generic<T>>]
+      # @return [generic<T>]
+      def create_object(clazz)
+        clazz.new
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [5, 15])
+    expect(clip.infer.tag).to eq('generic<T>')
+  end
+
+  it 'binds the generic at call sites of a Class<generic<T>>#new factory' do
+    source = Solargraph::Source.load_string(%(
+      # @generic T
+      # @param clazz [Class<generic<T>>]
+      # @return [generic<T>]
+      def create_object(clazz)
+        clazz.new
+      end
+      create_object(String)
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [7, 8])
+    expect(clip.infer.tag).to eq('String')
+  end
+
   it 'completes class instance variables in the namespace' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -925,5 +925,21 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it 'infers a return through .new on an unparameterized Class' do
+      checker = type_checker(%(
+        # @return [Object]
+        def plain_class_new
+          Class.new.new
+        end
+
+        # @return [Object]
+        def local_class_new
+          k = Class.new
+          k.new
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -941,5 +941,30 @@ describe Solargraph::TypeChecker do
       ))
       expect(checker.problems).to be_empty
     end
+
+    it 'infers a generic return through Class<generic<T>>#new' do
+      checker = type_checker(%(
+        # @generic T
+        # @param clazz [Class<generic<T>>]
+        # @return [generic<T>]
+        def create_object(clazz)
+          clazz.new
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'accepts arguments through Class<generic<T>>#new' do
+      checker = type_checker(%(
+        # @generic T
+        # @param clazz [Class<generic<T>>]
+        # @param opts [Hash{Symbol => Object}]
+        # @return [generic<T>]
+        def create_object_with_args(clazz, opts)
+          clazz.new(:sym, **opts)
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
   end
 end


### PR DESCRIPTION
**Parked: opened for future reference; the underlying defect is definition-site-only (callers are unaffected), so this waits until the problem is worth solving.**

## Problem

At `typecheck --level strong`, Solargraph cannot *verify* the declared return type of a method that calls `.new` through a `Class`-typed receiver: it reports "return type could not be inferred" at the definition and forces a suppression there. The failure is confined to the definition site. Callers are unaffected — the declared return resolves at call sites, so there is no viral `undefined` from this defect.

Both shapes below are ordinary Ruby. The first is the instantiate-the-class-under-test helper that every typed test suite grows:

```ruby
# @generic T
# @param clazz [Class<generic<T>>]
# @return [generic<T>]
def create_object(clazz)
  clazz.new       # => "return type could not be inferred", despite the generic
end

obj = create_object(MyCheck)  # obj types as MyCheck: legitimate calls check
                              # cleanly, bogus calls error - the declaration
                              # firewalls callers
```

The second is the throwaway-class idiom behind test doubles and one-off adapters — build an anonymous class implementing a duck interface, instantiate it once:

```ruby
# A responder object defining exactly the given no-op methods (test double)
# @param interface_methods [Array<Symbol>]
# @return [Object]
def duck_responder(interface_methods)
  Class.new do
    interface_methods.each { |m| define_method(m) { nil } }
  end.new   # => false error at the definition; @return [Object] already covers callers
end
```

(The `define_method` resolution *inside* the block is #1310's territory; this PR fixes the return inference.)

The value of this change is declaration verifiability — the definition typechecks against its own declared return, and the definition-site suppressions can be removed. It does not add caller-side coverage, which was never broken.

## Solution

`ApiMap#get_methods` already repairs the untyped `Class#new` pin per-namespace (synthesizing `new` from `initialize`), but misses two receiver shapes:

1. **Unparameterized `Class`** — the repair deliberately skips `rooted_tag` `Class`/`Class<Class>`. Now proxied: `Class.new` → `Class<Object>`, `.new` on a bare-`Class`-typed receiver → `Object`.
2. **`Class<generic<T>>`** — class-method lookup on the nonexistent `generic` namespace finds no `Class#new` at all. Now synthesized: a permissive (restarg/kwrestarg) `new` returning the generic tag, which caller-side binding already resolves.

The synthesized `Class<generic<T>>#new` accepts any arguments: the initializer is statically unknowable from that type, so argument checking is out of scope here. That trade is strictly non-regressive — today the call is unresolved at the definition, which means a false error *and* zero argument checking; the fix adds typed returns without adding new unsoundness. (Sorbet's `T::Class` docs similarly note the type "only assumes those [methods] that are defined on `::Class`… basically, just `.new` and `.name`," without documenting constructor-argument checking for such receivers.)

The new types are sound upper bounds: `Class<Object>` means "a class whose instances are (at least) Object," so `.new → Object` claims the bound, not the exact class — at runtime `Class.new.new` is an instance of a fresh anonymous class, never an Object-classed value. `Object` is chosen over the strictly-lower bound `BasicObject` because a `BasicObject`-typed result rejects nearly every subsequent call, and it matches Ruby's default superclass and existing core fills; the trade-off is one unsoundness edge for explicit `Class.new(BasicObject)` receivers, noted under alternatives.

## Background / prior art

Root cause: RBS cannot parameterize `Class`, so it declares [`Class#new: (*untyped, **untyped) -> untyped`](https://github.com/ruby/rbs/blob/v4.1.3/core/class.rbs#L165). At runtime, `Class.new` builds a fresh anonymous class (unnamed until assigned to a constant, superclass `Object` by default), and its instances inspect as `#<#<Class:0x...>:0x...>` — the inner `#<Class:0x...>` is the anonymous class's address-based display name, the outer wrapper the instance of it.

A [singleton class](https://docs.ruby-lang.org/en/master/syntax/modules_and_classes_rdoc.html#singleton-classes) "holds methods for only that instance," and the classic factory case — `Foo.new` — dispatches in `Foo`'s singleton class, which is where the attached-class mechanisms live: Sorbet's [`T.attached_class`](https://sorbet.org/docs/attached-class) ("an instance of the current class") and RBS's `instance` type are both resolved against that statically-known singleton context. Our two shapes operate **outside** any such context: the receiver is a *value* typed `Class`, so `.new` is instance-method dispatch on class `Class` and no singleton class is statically in play. Sorbet bridges that gap with the applied type [`T::Class[X]`](https://sorbet.org/docs/class-of) — "any class object which, when instantiated, creates instances that at least have type `X`" — an explicit upper bound built on the same mechanism as `T.attached_class`; RBS has no parameterization of `Class` at all, hence `untyped`. Solargraph's `Class<X>` is its `T::Class[X]` analog, and this PR supplies the most precise types expressible in Solargraph's current syntax under that reading.

Related but distinct: #1303 (constants assigned from `Class.new` blocks); #1310 addresses block-`self` inside `Class.new do ... end`.

## Alternative solutions

- **A first-class attached-class type in Solargraph's annotation syntax** — an `attached` token (named to avoid colliding with RBS's classish-context `instance` semantics), legal where the context supplies a `Class<X>`:

  ```ruby
  # In a Class#new annotation: resolves to X for a Class<X> receiver, Object for bare Class
  # @return [attached]
  # In a singleton-method context: the T.attached_class analog (instance of the current class or subclass)
  ```

  `Class#new` could then be declared once and the per-namespace `new` synthesis in `get_methods` — including both shapes fixed here — would collapse into a single declaration plus binder-aware substitution (the same shape as the existing `self` → `self_to_type` handling). Not taken in this PR because it is new public annotation syntax (YARD compatibility, documentation, cross-tool expectations) touching `ComplexType` parsing, dispatch substitution, and generics erasure; the bounded proxy needs none of that, and its two proxy sites are exactly where an `attached` token would later slot in.

- **Superclass-argument binding for `Class.new(Superclass)`** — conceptually `@generic T` / `@param superclass [Class<generic<T>>]` / `@return [Class<generic<T>>]` on the synthesized pin, inferring `Class<StandardError>` from `Class.new(StandardError)` and closing the `Class.new(BasicObject)` unsoundness edge. Three reasons it stays out of this PR. First, it semantically conflicts with the defect-2 fix in this same PR: superclass binding needs an *unbound generic to degrade to its bound* (no-arg `Class.new` must fall back to `Class<Object>`), while the `Class<generic<T>>#new` fix needs unbound generics *kept symbolic* for later caller-side binding — reconciling the two requires a design decision about when degradation happens, which deserves its own review. Second, blast radius: probed while preparing this PR, the pin synthesizes correctly (generics, typed optarg, generic return) but the chain layer's call-site binding does not engage for API-synthesized pins — the unresolved `Class<generic<T>>` flows through and the no-arg case regresses to symbolic — so the fix lands in chain-layer resolution code that affects every method call, versus this PR's repair of one method's pin. Third, marginal value: `Class.new(Superclass)` results that need precise typing are typically assigned to constants, which is #1303's territory regardless of what the expression infers. The static `Class<Object>` proxy is forward-compatible with adding the binding later.

## Test plan

Two clip specs updated from asserting `undefined`, six added (both shapes, caller-side generic binding, args-through-generic-new). Full suite: 1630 examples, 0 failures, 60 pending.

*Opened as a draft. This PR was written by Claude (Anthropic's Claude Code) on behalf of @apiology.*
