### PR TITLE
Destructure block parameter groups and keep union-typed tuple elements in one position

### DIFF
--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -416,8 +416,8 @@ module Solargraph
       # @return [Array<ComplexType>]
       def resolve_param_generics_from_context generics_to_resolve, context_type, resolved_generic_values
         types = yield self
-        types.each_with_index.flat_map do |ct, i|
-          ct.items.flat_map do |ut|
+        types.each_with_index.map do |ct, i|
+          resolved = ct.items.flat_map do |ut|
             context_params = yield context_type if context_type
             if context_params && context_params[i]
               type_arg = context_params[i]
@@ -426,10 +426,16 @@ module Solargraph
                                                  resolved_generic_values: resolved_generic_values
               end
             else
-              ut.resolve_generics_from_context generics_to_resolve, nil,
-                                               resolved_generic_values: resolved_generic_values
+              [ut.resolve_generics_from_context(generics_to_resolve, nil,
+                                                resolved_generic_values: resolved_generic_values)]
             end
           end
+          # A single position's resolution may be a union (e.g. a Hash key
+          # type of `String, Symbol` binding one slot of the yielded
+          # [K, V] pair). Keep the union inside one parameter position
+          # instead of splicing its members into extra positions, which
+          # inflates a tuple's arity (Array(K, V) must stay a pair).
+          ComplexType.new(resolved.flat_map { |t| t.is_a?(ComplexType) ? t.items : [t] })
         end
       end
 
@@ -547,8 +553,12 @@ module Solargraph
           new_key_types = @key_types
           new_subtypes = @subtypes
         else
-          new_key_types = @key_types.flat_map { |ct| ct.items.map { |ut| ut.transform(&transform_type) } }
-          new_subtypes = @subtypes.flat_map { |ct| ct.items.map { |ut| ut.transform(&transform_type) } }
+          # Rebuild per parameter position: a position holding (or
+          # transformed into) a union must stay one position, not have
+          # its members spliced in as extra positions (which would
+          # inflate a tuple's arity).
+          new_key_types = @key_types.map { |ct| transform_position(ct, &transform_type) }
+          new_subtypes = @subtypes.map { |ct| transform_position(ct, &transform_type) }
         end
         new_type = recreate(new_name: new_name || name, new_key_types: new_key_types, new_subtypes: new_subtypes,
                             make_rooted: @rooted)
@@ -557,6 +567,18 @@ module Solargraph
 
       def expand named_types
         named_types[name] || self
+      end
+
+      # Transform one parameter position, keeping however many types the
+      # transformation produces inside that single position.
+      #
+      # @param position_type [ComplexType]
+      # @yieldparam t [UniqueType]
+      # @yieldreturn [self]
+      # @return [ComplexType]
+      def transform_position position_type, &transform_type
+        results = position_type.items.map { |ut| ut.transform(&transform_type) }
+        ComplexType.new(results.flat_map { |t| t.is_a?(ComplexType) ? t.items : [t] })
       end
 
       # Generate a ComplexType that fully qualifies this type's namespaces.

--- a/lib/solargraph/parser/parser_gem/node_processors/args_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/args_node.rb
@@ -12,6 +12,10 @@ module Solargraph
                 forward(callable)
               else
                 node.children.each do |u|
+                  if u.type == :mlhs
+                    process_mlhs_param(callable, u)
+                    next
+                  end
                   loc = get_node_location(u)
                   locals.push Solargraph::Pin::Parameter.new(
                     location: loc,
@@ -53,6 +57,56 @@ module Solargraph
           # @return [Symbol]
           def get_decl node
             node.type
+          end
+
+          # A destructured parameter group (`|(a, b), c|`). The group
+          # itself occupies one position in the block signature; the
+          # variables inside it are locals whose types are projected from
+          # the group's tuple type by element position (see
+          # Pin::Parameter#mlhs_path).
+          #
+          # @param callable [Pin::Callable]
+          # @param mlhs_node [AST::Node]
+          # @return [void]
+          def process_mlhs_param callable, mlhs_node
+            loc = get_node_location(mlhs_node)
+            locals.push Solargraph::Pin::Parameter.new(
+              location: loc,
+              closure: callable,
+              comments: comments_for(node),
+              name: region.code_for(mlhs_node) || '()',
+              # @sg-ignore Need to add nil check here
+              presence: callable.location.range,
+              decl: :mlhs,
+              source: :parser
+            )
+            callable.parameters.push locals.last
+            add_mlhs_locals callable, mlhs_node, [callable.parameters.length - 1]
+          end
+
+          # @param callable [Pin::Callable]
+          # @param mlhs_node [AST::Node]
+          # @param path [::Array<Integer>]
+          # @return [void]
+          def add_mlhs_locals callable, mlhs_node, path
+            mlhs_node.children.each_with_index do |child, i|
+              if child.type == :mlhs
+                add_mlhs_locals callable, child, path + [i]
+              else
+                loc = get_node_location(child)
+                locals.push Solargraph::Pin::Parameter.new(
+                  location: loc,
+                  closure: callable,
+                  comments: comments_for(node),
+                  name: child.children[0].to_s,
+                  # @sg-ignore Need to add nil check here
+                  presence: callable.location.range,
+                  decl: :arg,
+                  mlhs_path: path + [i],
+                  source: :parser
+                )
+              end
+            end
           end
         end
       end

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -54,6 +54,24 @@ module Solargraph
         parameters.map.with_index { |_, idx| yield_types[idx] || ComplexType::UNDEFINED }
       end
 
+      # Whether the yielded types line up with the block's parameters one
+      # for one - either a tuple destructured across them, or one yielded
+      # type per parameter. When they do not (Ruby auto-splats a single
+      # yielded value whose arity we cannot match), the fallback in
+      # destructure_yield_types hands position 0 the whole value, which is
+      # worse than leaving the parameters undefined.
+      #
+      # @param yield_types [::Array<ComplexType>]
+      # @param parameters [::Array<Parameter>]
+      # @return [Boolean]
+      def per_position_yield_types? yield_types, parameters
+        return true if yield_types.length == parameters.length
+
+        yield_types.length == 1 &&
+          yield_types.first.tuple? &&
+          yield_types.first.all_params.length == parameters.length
+      end
+
       # @param api_map [ApiMap]
       # @return [::Array<ComplexType>]
       def typify_parameters api_map
@@ -92,8 +110,11 @@ module Solargraph
 
           # remember the best partial result so a single unresolvable
           # yield type (e.g. an unbound generic) doesn't discard the
-          # positions that did resolve
-          partial ||= param_types if param_types.any? { |t| t&.defined? }
+          # positions that did resolve - but only when the positions
+          # actually correspond, never for the auto-splat fallback
+          if per_position_yield_types?(yield_types, parameters) && param_types.any? { |t| t&.defined? }
+            partial ||= param_types
+          end
         end
         partial&.map { |t| t || ComplexType::UNDEFINED } || parameters.map { ComplexType::UNDEFINED }
       end

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -66,10 +66,12 @@ module Solargraph
       # @return [Boolean]
       def per_position_yield_types? yield_types, parameters
         return true if yield_types.length == parameters.length
+        return false unless yield_types.length == 1
 
-        yield_types.length == 1 &&
-          yield_types.first.tuple? &&
-          yield_types.first.all_params.length == parameters.length
+        only_type = yield_types.first
+        return false if only_type.nil?
+
+        only_type.tuple? && only_type.all_params.length == parameters.length
       end
 
       # @param api_map [ApiMap]

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -63,6 +63,8 @@ module Solargraph
         locals = clip.locals - [self]
         # @sg-ignore Need to add nil check here
         meths = chain.define(api_map, closure, locals)
+        # @type [::Array<ComplexType>, nil]
+        partial = nil
         # @todo Convert logic to use signatures
         # @param meth [Pin::Method]
         meths.each do |meth|
@@ -87,8 +89,13 @@ module Solargraph
             end
           end
           return param_types if param_types.all?(&:defined?)
+
+          # remember the best partial result so a single unresolvable
+          # yield type (e.g. an unbound generic) doesn't discard the
+          # positions that did resolve
+          partial ||= param_types if param_types.any? { |t| t&.defined? }
         end
-        parameters.map { ComplexType::UNDEFINED }
+        partial&.map { |t| t || ComplexType::UNDEFINED } || parameters.map { ComplexType::UNDEFINED }
       end
 
       private

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -6,21 +6,29 @@ module Solargraph
       # @return [::Symbol]
       attr_reader :decl
 
-      # @return [String]
+      # @return [String, nil]
       attr_reader :asgn_code
 
       # allow this to be set to the method after the method itself has
       # been created
       attr_writer :closure
 
-      # @param decl [::Symbol] :arg, :optarg, :kwarg, :kwoptarg, :restarg, :kwrestarg, :block, :blockarg
+      # @param decl [::Symbol] :arg, :optarg, :kwarg, :kwoptarg, :restarg, :kwrestarg, :block, :blockarg, :mlhs
       # @param asgn_code [String, nil]
+      # @param mlhs_path [::Array<Integer>, nil] for a variable inside a
+      #   destructured block parameter group (`|(a, b), c|`): the group's
+      #   position in the block signature followed by the element index at
+      #   each nesting level (`a` -> [0, 0], `b` -> [0, 1])
       # @param [Hash{Symbol => Object}] splat
-      def initialize decl: :arg, asgn_code: nil, **splat
+      def initialize decl: :arg, asgn_code: nil, mlhs_path: nil, **splat
         super(**splat)
         @asgn_code = asgn_code
         @decl = decl
+        @mlhs_path = mlhs_path
       end
+
+      # @return [::Array<Integer>, nil]
+      attr_reader :mlhs_path
 
       def type_location
         super || closure&.type_location
@@ -211,6 +219,11 @@ module Solargraph
         new_type = super
         return new_type if new_type.defined?
 
+        if mlhs_path && closure.is_a?(Pin::Block)
+          projected = typify_mlhs_element(api_map)
+          return adjust_type api_map, projected.self_to_type(full_context) if projected.defined?
+        end
+
         # sniff based on param tags
         new_type = closure.is_a?(Pin::Block) ? typify_block_param(api_map) : typify_method_param(api_map)
 
@@ -306,11 +319,33 @@ module Solargraph
         params[index] if index && params[index] && (params[index].name.nil? || params[index].name.empty?)
       end
 
+      # Project this variable's type out of its destructured parameter
+      # group's tuple type, one element index per nesting level.
+      #
+      # @param api_map [ApiMap]
+      # @return [ComplexType]
+      def typify_mlhs_element api_map
+        block_pin = closure
+        path = mlhs_path
+        return ComplexType::UNDEFINED unless path && block_pin.is_a?(Pin::Block) && block_pin.receiver
+
+        type = block_pin.typify_parameters(api_map)[path.first]
+        path.drop(1).each do |idx|
+          return ComplexType::UNDEFINED if type.nil? || !type.tuple?
+
+          type = type.all_params[idx]
+        end
+        type || ComplexType::UNDEFINED
+      end
+
       # @param api_map [ApiMap]
       # @return [ComplexType]
       def typify_block_param api_map
         block_pin = closure
-        return block_pin.typify_parameters(api_map)[index] if block_pin.is_a?(Pin::Block) && block_pin.receiver && index
+        if block_pin.is_a?(Pin::Block) && block_pin.receiver && index
+          typed = block_pin.typify_parameters(api_map)[index]
+          return typed unless typed.nil?
+        end
         ComplexType::UNDEFINED
       end
 
@@ -328,8 +363,9 @@ module Solargraph
             found = p
             break
           end
-          if found.nil? && !index.nil? && params[index] && (params[index].name.nil? || params[index].name.empty?)
-            found = params[index]
+          if found.nil? && !index.nil?
+            positional = params[index]
+            found = positional if positional && (positional.name.nil? || positional.name.empty?)
           end
           unless found.nil? || found.types.nil?
             return ComplexType.try_parse(*found.types).qualify(api_map,
@@ -366,7 +402,7 @@ module Solargraph
         return nil if skip.include?(ref)
         skip.push ref
         parts = ref.split(/[.#]/)
-        if parts.first.empty?
+        if parts.first.to_s.empty?
           path = "#{namespace}#{ref}"
         else
           fqns = api_map.qualify(parts.first, namespace)

--- a/spec/type_checker/levels/destructuring_spec.rb
+++ b/spec/type_checker/levels/destructuring_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+describe Solargraph::TypeChecker do
+  context 'with level set to strong, destructuring' do
+    def type_checker code
+      Solargraph::TypeChecker.load_string(code, 'test.rb', :strong)
+    end
+
+    it 'destructures tuple elements onto flat block parameters' do
+      checker = type_checker(%(
+        class TupleBlocks
+          # @return [Array<Array(String, Integer)>]
+          def pairs
+            [['a', 1]]
+          end
+
+          # @return [Array<String>]
+          def flat_params
+            pairs.map { |name, count| "\#{name.upcase} \#{count.succ}" }
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).not_to include('Unresolved call to upcase')
+      expect(checker.problems.map(&:message)).not_to include('Unresolved call to succ')
+    end
+
+    it 'projects Hash#each pair types onto block parameters' do
+      checker = type_checker(%(
+        class HashPairs
+          # @return [Hash{Symbol => Array<String>}]
+          def dict
+            { a: ['x'] }
+          end
+
+          # @return [void]
+          def each_pair
+            dict.each { |key, vals| puts "\#{key.to_proc} \#{vals.length}" }
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).not_to include('Unresolved call to to_proc')
+      expect(checker.problems.map(&:message)).not_to include('Unresolved call to length')
+    end
+
+    it 'projects tuple element types into a destructured parameter group' do
+      source = Solargraph::Source.load_string(%(
+        class MlhsGroup
+          # @return [Array<Array(String, Integer)>]
+          def pairs
+            [['a', 1]]
+          end
+
+          # @return [Hash{String => Integer}]
+          def grouped
+            pairs.each_with_object({}) do |(name, count), memo|
+              memo[name.upcase] = count.succ
+            end
+          end
+        end
+      ), 'test.rb')
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      locals = api_map.source_map('test.rb').locals
+      name_pin = locals.find { |l| l.name == 'name' }
+      count_pin = locals.find { |l| l.name == 'count' }
+      # without mlhs support the variables inside the group do not exist
+      # as local pins at all
+      expect(name_pin).not_to be_nil
+      expect(count_pin).not_to be_nil
+      expect(name_pin.typify(api_map).tag).to eq('String')
+      expect(count_pin.typify(api_map).tag).to eq('Integer')
+    end
+  end
+end

--- a/spec/type_checker/levels/destructuring_spec.rb
+++ b/spec/type_checker/levels/destructuring_spec.rb
@@ -70,5 +70,72 @@ describe Solargraph::TypeChecker do
       expect(name_pin.typify(api_map).tag).to eq('String')
       expect(count_pin.typify(api_map).tag).to eq('Integer')
     end
+
+    it 'keeps a union-typed pair element in one tuple position (Hash#each with union key)' do
+      checker = type_checker(%(
+        class UnionKeyDict
+          # @return [Hash{String, Symbol => Integer}]
+          def dict
+            { 'a' => 1, b: 2 }
+          end
+
+          # @return [void]
+          def each_pair
+            dict.each { |key, count| puts "\#{key.to_s} \#{count.succ}" }
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'keeps a nilable pair element in one tuple position' do
+      source = Solargraph::Source.load_string(%(
+        class NilableKeyDict
+          # @return [Hash{String, nil => Array<String>}]
+          def dict
+            { 'a' => ['x'], nil => [] }
+          end
+
+          # @return [void]
+          def each_pair
+            dict.each do |section, tasks|
+              puts tasks.length if section.nil?
+            end
+          end
+        end
+      ), 'test.rb')
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      locals = api_map.source_map('test.rb').locals
+      section = locals.find { |l| l.name == 'section' }
+      tasks = locals.find { |l| l.name == 'tasks' }
+      expect(section.typify(api_map).to_s).to match(/\AString, (nil|NilClass)\z/)
+      expect(tasks.typify(api_map).to_s).to eq('Array<String>')
+    end
+
+    it 'projects a union element through a destructured parameter group' do
+      source = Solargraph::Source.load_string(%(
+        class UnionMlhs
+          # @return [Hash{String, Symbol => Integer}]
+          def dict
+            { 'a' => 1 }
+          end
+
+          # @return [Hash{String => Integer}]
+          def grouped
+            dict.each_with_object({}) do |(key, count), memo|
+              memo[key.to_s] = count
+            end
+          end
+        end
+      ), 'test.rb')
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      locals = api_map.source_map('test.rb').locals
+      key = locals.find { |l| l.name == 'key' }
+      count = locals.find { |l| l.name == 'count' }
+      expect(key.typify(api_map).to_s).to eq('String, Symbol')
+      expect(count.typify(api_map).to_s).to eq('Integer')
+    end
   end
 end

--- a/spec/type_checker/levels/destructuring_spec.rb
+++ b/spec/type_checker/levels/destructuring_spec.rb
@@ -137,5 +137,81 @@ describe Solargraph::TypeChecker do
       expect(key.typify(api_map).to_s).to eq('String, Symbol')
       expect(count.typify(api_map).to_s).to eq('Integer')
     end
+
+    it 'destructures a Hash#each pair across two plain block parameters' do
+      checker = type_checker(%(
+        class PlainHashEach
+          # @return [Hash{String, Symbol => Array<Integer>}]
+          def dict
+            { 'a' => [1] }
+          end
+
+          # @return [void]
+          def each_pair
+            dict.each { |key, vals| puts "\#{key.to_s} \#{vals.length}" }
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'destructures an Array of tuples across two plain block parameters' do
+      checker = type_checker(%(
+        class PlainTuplePair
+          # @return [Array<Array(String, Integer)>]
+          def pairs
+            [['a', 1]]
+          end
+
+          # @return [Array<String>]
+          def described
+            pairs.map { |name, count| "\#{name.upcase} \#{count.succ}" }
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'leaves parameters undefined rather than assigning a whole auto-splatted value' do
+      # A 4-parameter proc yields no per-position types; position 0 must
+      # not be handed the whole yielded value (which produced bogus
+      # "Wrong argument type ... received Array" errors)
+      source = Solargraph::Source.load_string(%(
+        class SplatFallback
+          # @return [Proc]
+          def on_retry
+            proc { |exception, try, elapsed, next_int| [exception, try, elapsed, next_int] }
+          end
+        end
+      ), 'test.rb')
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      locals = api_map.source_map('test.rb').locals
+      %w[exception try elapsed next_int].each do |name|
+        pin = locals.find { |l| l.name == name }
+        expect(pin.typify(api_map)).to be_undefined
+      end
+    end
+
+    it 'does not hand a non-matching-arity yielded value to the first parameter' do
+      checker = type_checker(%(
+        class ArityMismatch
+          # @return [Array<Array<String, nil>>]
+          def loose_pairs
+            [['a', nil]]
+          end
+
+          # @return [Hash{String => String}]
+          def collect
+            # @type [Hash{String => String}]
+            hash = {}
+            loose_pairs.each { |key, value| hash[key] = value.to_s }
+            hash
+          end
+        end
+      ))
+      # key must not be typed as the whole Array<String, nil>
+      expect(checker.problems.map(&:message)).not_to(include(a_string_matching(/Wrong argument type.*key/)))
+    end
   end
 end


### PR DESCRIPTION
`|(name, count), memo|` produced no local pins at all for `name`/`count` (every reference was an unresolved call), and a `Hash#each` block over a union-keyed hash reported false "Wrong argument type ... received Array(String, nil, V)" errors because the key union's members were spliced into extra tuple positions.

```ruby
# @return [Hash{String, Symbol => Integer}]
def dict; { 'a' => 1, b: 2 }; end

dict.each { |key, count| key.to_s; count.succ }  # was: count unresolved
dict.each_with_object({}) do |(key, count), memo|  # was: key/count not locals at all
```

Two changes on top of #1223: (1) a destructured group registers as one `:mlhs` parameter holding its signature position; each variable inside becomes a local typed by projecting the group's tuple type per element index (nesting supported via an index path). (2) Generic resolution rebuilds type parameters per position, so a union binding one tuple slot stays one slot.

Makes three previously-pending clip specs pass (un-pended here).

Known limitations: tag rendering of a multi-item position is still ambiguous (`Array(String, nil, Integer)`), so positions survive in memory but not a `to_s`/parse round trip — follow-up. The partial-result fallback applies only when the yielded types correspond to the block's parameters one for one (a tuple destructured across them, or one yielded type per parameter); a single auto-splatted value whose arity cannot be matched leaves the parameters undefined rather than assigning the whole value to parameter 0.

Test plan: 10 new specs (fail-before verified), including four pinning plain multi-parameter destructuring; full suite 1,610 examples, 0 failures.

🤖 This PR was written by Claude (Anthropic's AI assistant) on behalf of @apiology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1FEjW6nMpZrWPmeWX9miT
