### PR TITLE
Prefer a block signature that declares parameters

### DIFF
--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -102,7 +102,7 @@ module Solargraph
             # @type Array<Pin::Signature>
             sorted_overloads = yielding + non_yielding + without_block
             # @type [Pin::Signature, nil]
-            new_signature_pin = nil
+            selected_signature_pin = nil
             # @sg-ignore flow sensitive typing should handle is_a? and next
             # @param ol [Pin::Signature]
             sorted_overloads.each do |ol|
@@ -171,10 +171,14 @@ module Solargraph
                   type = with_params(new_return_type.self_to_type(self_type), self_type).qualify(api_map, *p.gates)
                 end
                 type ||= ComplexType::UNDEFINED
+                # Signatures are tried in preference order, so the first to
+                # match is the best available match. A later one may replace
+                # it only by supplying the return type it could not.
+                selected_signature_pin = new_signature_pin if selected_signature_pin.nil? || type.defined?
               end
               break if type.defined?
             end
-            p = p.with_single_signature(new_signature_pin) unless new_signature_pin.nil?
+            p = p.with_single_signature(selected_signature_pin) unless selected_signature_pin.nil?
             next p.proxy(type) if type.defined?
             p
           end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -88,9 +88,19 @@ module Solargraph
             # reject it regardless
 
             with_block, without_block = overloads.partition(&:block?)
+            # A signature whose block declares no yielded parameters
+            # (e.g. a `&block` parameter documented with no @yieldparam,
+            # which yields `{ () -> }`) says nothing about what the block
+            # receives. When a sibling signature declares yielded
+            # parameters, try that one first: the block's parameters
+            # resolve from whichever signature is selected here, and Ruby
+            # blocks accept fewer arguments than are yielded, so the
+            # parameterized signature is the strictly more informative
+            # match whenever both are otherwise equally applicable.
+            yielding, non_yielding = with_block.partition { |sig| !sig.block.parameters.empty? }
             # @sg-ignore flow sensitive typing should handle is_a? and next
             # @type Array<Pin::Signature>
-            sorted_overloads = with_block + without_block
+            sorted_overloads = yielding + non_yielding + without_block
             # @type [Pin::Signature, nil]
             new_signature_pin = nil
             # @sg-ignore flow sensitive typing should handle is_a? and next

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1965,6 +1965,89 @@ describe Solargraph::SourceMap::Clip do
     expect(type.tag).to eq('String')
   end
 
+  it 'yields the block parameter type declared by a cross-file @!parse stub' do
+    # The plain implementation (e.g., as it would be defined in a gem)
+    # documents only that it takes a block, yielding the signature
+    # `{ () -> }`. It's mapped first, simulating a gem's pins being
+    # loaded before the workspace's.
+    plain_impl = Solargraph::SourceMap.load_string(%(
+      module Widgetbox
+        class Collection
+          # @return [String]
+          def name
+            'collection'
+          end
+        end
+
+        class << self
+          # @return [Widgetbox::Collection]
+          def build(&block)
+            Collection.new
+          end
+        end
+      end
+    ), 'widgetbox.rb')
+    # A `@!parse` stub in a separate file declares what the block receives.
+    parse_stub = Solargraph::SourceMap.load_string(%(
+      # @!parse
+      #   module Widgetbox
+      #     class << self
+      #       # @yieldparam config [Widgetbox::Collection]
+      #       # @return [Widgetbox::Collection]
+      #       def build(&block); end
+      #     end
+      #   end
+    ), 'annotations.rb')
+    caller_source = Solargraph::Source.load_string(%(
+      Widgetbox.build do |config|
+        config
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.catalog Solargraph::Bench.new(source_maps: [plain_impl, parse_stub, Solargraph::SourceMap.map(caller_source)])
+    clip = api_map.clip_at('test.rb', [2, 14])
+    expect(clip.infer.tag).to eq('Widgetbox::Collection')
+  end
+
+  it 'yields the block parameter type when the gem side declares no block at all' do
+    plain_impl = Solargraph::SourceMap.load_string(%(
+      module Widgetbox
+        class Collection
+          # @return [String]
+          def name
+            'collection'
+          end
+        end
+
+        class << self
+          # @return [Widgetbox::Collection]
+          def build
+            Collection.new
+          end
+        end
+      end
+    ), 'widgetbox.rb')
+    parse_stub = Solargraph::SourceMap.load_string(%(
+      # @!parse
+      #   module Widgetbox
+      #     class << self
+      #       # @yieldparam config [Widgetbox::Collection]
+      #       # @return [Widgetbox::Collection]
+      #       def build(&block); end
+      #     end
+      #   end
+    ), 'annotations.rb')
+    caller_source = Solargraph::Source.load_string(%(
+      Widgetbox.build do |config|
+        config
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.catalog Solargraph::Bench.new(source_maps: [plain_impl, parse_stub, Solargraph::SourceMap.map(caller_source)])
+    clip = api_map.clip_at('test.rb', [2, 14])
+    expect(clip.infer.tag).to eq('Widgetbox::Collection')
+  end
+
   it 'uses simple return value of block to infer return value of Enumerable#map' do
     source = Solargraph::Source.load_string(%(
       a = ['a'].map { 123 }

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -2048,6 +2048,45 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.infer.tag).to eq('Widgetbox::Collection')
   end
 
+  it 'keeps the matched block signature when a blockless sibling signature also matches' do
+    # Neither signature declares a return type, so no signature can end
+    # the search by producing one. The blockless `def build; end` matches
+    # the call as well - Ruby accepts a block for any method - and is
+    # tried after the block-carrying signature from the @!parse stub.
+    plain_impl = Solargraph::SourceMap.load_string(%(
+      module Widgetbox
+        class Collection
+          # @return [String]
+          def name
+            'collection'
+          end
+        end
+
+        class << self
+          def build; end
+        end
+      end
+    ), 'widgetbox.rb')
+    parse_stub = Solargraph::SourceMap.load_string(%(
+      # @!parse
+      #   module Widgetbox
+      #     class << self
+      #       # @yieldparam config [Widgetbox::Collection]
+      #       def build(&block); end
+      #     end
+      #   end
+    ), 'annotations.rb')
+    caller_source = Solargraph::Source.load_string(%(
+      Widgetbox.build do |config|
+        config
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.catalog Solargraph::Bench.new(source_maps: [plain_impl, parse_stub, Solargraph::SourceMap.map(caller_source)])
+    clip = api_map.clip_at('test.rb', [2, 14])
+    expect(clip.infer.tag).to eq('Widgetbox::Collection')
+  end
+
   it 'uses simple return value of block to infer return value of Enumerable#map' do
     source = Solargraph::Source.load_string(%(
       a = ['a'].map { 123 }


### PR DESCRIPTION
A block parameter resolves as `undefined` when a gem's yardoc and a workspace
`@!parse` stub both declare a method and only the stub declares the yield:

```ruby
# in the gem
module Widgetbox
  class << self
    # @return [String]
    def build(&block) = 'x'
  end
end

# in the workspace
# @!parse
#   module Widgetbox
#     class << self
#       # @yieldparam config [String]
#       # @return [String]
#       def build(&block); end
#     end
#   end

Widgetbox.build { |config| config.upcase } # Unresolved call to upcase
```

`ApiMap::Store` combines the pins into one carrying two signatures. The gem's
bare `&block` yields `{ () -> }`, and `Chain::Call` took the first, never
reading the stub's `@yieldparam`.

Signatures whose block declares parameters now sort ahead. That changes the
outcome only where both already matched the call's arity and arguments and the
winner was arbitrary.

Two adjacent shapes remain uncovered: a stub without `@return`, whose
signatures `combine_signatures` discards as all-undefined, and a gem using
`def self.build` against a stub using `class << self`, where the pins never
combine.

Based on #1288, whose store combining produces the two-signature pin. On
`master` the `@!parse` pin is discarded by `[stack.first].compact` before
selection runs, so the two-signature pin does not exist and this sort has
nothing to reorder — the symptom is the same there, by a different mechanism.

This PR was written by Claude Code on behalf of @apiology.
