### PR TITLE
Demo only: show the solargraph-rails Array#sum fix in plugin CI

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -31,7 +31,7 @@ jobs:
         version: 1.0
     - name: Install gems
       run: |
-        echo 'gem "solargraph-rails"' > .Gemfile
+        echo 'gem "solargraph-rails", git: "https://github.com/iftheshoefritz/solargraph-rails.git", branch: "drop-array-sum-annotation"' > .Gemfile
         echo 'gem "solargraph-rspec"' >> .Gemfile
         # Add optional gem to be able to typecheck related code
         echo "gem 'vernier', '>1.0', '<2'" >> .Gemfile
@@ -65,7 +65,7 @@ jobs:
         version: 1.0
     - name: Install gems
       run: |
-        echo 'gem "solargraph-rails"' > .Gemfile
+        echo 'gem "solargraph-rails", git: "https://github.com/iftheshoefritz/solargraph-rails.git", branch: "drop-array-sum-annotation"' > .Gemfile
         # Add optional gem to be able to typecheck related code
         echo "gem 'vernier', '>1.0', '<2'" >> .Gemfile
         bundle install
@@ -182,7 +182,7 @@ jobs:
     - name: clone solargraph-rails
       run: |
        cd ..
-       git clone https://github.com/iftheshoefritz/solargraph-rails.git
+       git clone --branch drop-array-sum-annotation https://github.com/iftheshoefritz/solargraph-rails.git
        cd solargraph-rails
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
**Claude:**

## Do not merge

This branch exists only to produce CI logs. It pins `solargraph-rails` to a branch in a third-party repository (`iftheshoefritz/solargraph-rails` @ `drop-array-sum-annotation`), which will be deleted once iftheshoefritz/solargraph-rails#211 merges — at which point every job here breaks. Close it once the logs have been read.

## What it demonstrates

iftheshoefritz/solargraph-rails#211 deletes `def sum; end` from the plugin's `lib/solargraph/rails/annotations/array.rb`. That stub contributes an arity-0, blockless `() -> untyped` overload to the combined `Array#sum` pin, alongside core rbs's `(?untyped init) ?{ (E e) -> untyped } -> untyped`. When the blockless overload wins, the block parameter in `key_types.sum { |t| t.items.length }` loses its element type.

## Expected outcome

The `rails` and `regression` jobs should drop from **4 problems to 2**, losing both of:

```
lib/solargraph/complex_type/type_methods.rb:219: Unresolved call to items
lib/solargraph/complex_type/type_methods.rb:219: Unresolved call to items
```

and keeping both `Unneeded @sg-ignore comment` results.

## Note on the diff

The `rails` and `regression` jobs install `solargraph-rails` from RubyGems via `.Gemfile`, not from the `git clone` in `run_solargraph_rails_specs`. Changing only the clone target would have left those two jobs on the released gem, so the two `.Gemfile` lines are pinned to the branch as well. The clone target is changed too, so `run_solargraph_rails_specs` exercises the same branch.

This PR was written by Claude Code on behalf of @apiology.
