### PR TITLE
Check keyword arguments passed through a ** splat

### DIFF
--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -195,6 +195,16 @@ module Solargraph
         non_literal_name != name
       end
 
+      # Whether this type's tag is a literal value (`:a`, `"Index"`, `1`,
+      # `true`) rather than a class name. Unlike #literal?, this does not
+      # take part in type inference; it only reports what the tag says, so
+      # a literal written in an annotation survives qualification.
+      #
+      # @return [Boolean]
+      def literal_tag?
+        non_literal_name != name
+      end
+
       # @return [String]
       def non_literal_name
         @non_literal_name ||= determine_non_literal_name
@@ -618,17 +628,28 @@ module Solargraph
       # @param gates [Array<String>] The namespaces from which to resolve names
       # @return [self, ComplexType, UniqueType] The generated ComplexType
       def qualify api_map, *gates
-        transform do |t|
-          next t if t.name == GENERIC_TAG_NAME
-          next t if t.duck_type? || t.void? || t.undefined? || t.literal?
-          open = t.rooted? ? [''] : gates
-          fqns = api_map.qualify(t.non_literal_name, *open)
-          if fqns.nil?
-            next UniqueType::BOOLEAN if t.tag == 'Boolean'
-            next UniqueType::UNDEFINED
+        if name == GENERIC_TAG_NAME
+          new_key_types = @key_types
+          new_subtypes = @subtypes
+        else
+          # A literal key tag is the one place a literal has to survive
+          # qualification: widening `:a` to Symbol in `Hash{:a => String}`
+          # would erase which key the type is talking about. Literals
+          # elsewhere still widen to their class.
+          new_key_types = @key_types.flat_map do |ct|
+            ct.items.map { |ut| ut.literal_tag? ? ut : ut.qualify(api_map, *gates) }
           end
-          t.recreate(new_name: fqns, make_rooted: true)
+          new_subtypes = @subtypes.flat_map { |ct| ct.items.map { |ut| ut.qualify(api_map, *gates) } }
         end
+        qualified = recreate(new_key_types: new_key_types, new_subtypes: new_subtypes)
+        return qualified if name == GENERIC_TAG_NAME || duck_type? || void? || undefined? || literal?
+        open = rooted? ? [''] : gates
+        fqns = api_map.qualify(non_literal_name, *open)
+        if fqns.nil?
+          return UniqueType::BOOLEAN if tag == 'Boolean'
+          return UniqueType::UNDEFINED
+        end
+        qualified.recreate(new_name: fqns, make_rooted: true)
       end
 
       def selfy?

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -164,6 +164,16 @@ module Solargraph
           Intersection.new(conjuncts.map { |conjunct| conjunct.transform(new_name, &transform_type) })
         end
 
+        # UniqueType#qualify walks key_types and subtypes; an
+        # intersection holds neither, so it qualifies its conjuncts.
+        #
+        # @param api_map [ApiMap]
+        # @param gates [Array<String>]
+        # @return [Intersection]
+        def qualify api_map, *gates
+          Intersection.new(conjuncts.map { |conjunct| conjunct.qualify(api_map, *gates) })
+        end
+
         # @return [self]
         def erase_parameters
           self

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -158,14 +158,19 @@ module Solargraph
           result
         end
 
+        # Whether the hash passes along keys that are not in the node -
+        # `foo(**args)` or `foo(a: 1, **args)`, but not `foo(**{ a: 1 })`,
+        # whose keys are right there.
+        #
         # @param node [Parser::AST::Node]
         def hash_is_splatted? node
           return false unless Parser.is_ast_node?(node) && node.type == :hash
-          return false unless Parser.is_ast_node?(node.children.last) && node.children.last.type == :kwsplat
-          if Parser.is_ast_node?(node.children.last.children[0]) && node.children.last.children[0].type == :hash
-            return false
+          node.children.any? do |child|
+            # @sg-ignore Translate to something flow sensitive typing understands
+            next false unless Parser.is_ast_node?(child) && child.type == :kwsplat
+            # @sg-ignore Translate to something flow sensitive typing understands
+            !(Parser.is_ast_node?(child.children[0]) && child.children[0].type == :hash)
           end
-          true
         end
 
         # @param node [Parser::AST::Node]

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -144,6 +144,12 @@ module Solargraph
           result
         end
 
+        # The keyword arguments a hash node passes by name. A `**` splat
+        # of a literal hash contributes that hash's own keys; a `**` splat
+        # of anything else contributes none, because the keys are not in
+        # the node - see NodeChainer.hash_is_splatted? for the predicate
+        # that tells the two apart.
+        #
         # @param node [Parser::AST::Node, nil]
         # @return [Hash{Symbol => Chain}]
         def convert_hash node
@@ -151,15 +157,16 @@ module Solargraph
           # @sg-ignore Translate to something flow sensitive typing understands
           return convert_hash(node.children[0]) if node.type == :kwsplat
           # @sg-ignore Translate to something flow sensitive typing understands
-          if Parser.is_ast_node?(node.children[0]) && node.children[0].type == :kwsplat
-            # @sg-ignore Translate to something flow sensitive typing understands
-            return convert_hash(node.children[0])
-          end
-          # @sg-ignore Translate to something flow sensitive typing understands
           return {} unless node.type == :hash
           result = {}
           # @sg-ignore Translate to something flow sensitive typing understands
           node.children.each do |pair|
+            next unless Parser.is_ast_node?(pair)
+            if pair.type == :kwsplat
+              result.merge!(convert_hash(pair))
+              next
+            end
+            next unless Parser.is_ast_node?(pair.children[0])
             result[pair.children[0].children[0]] = Solargraph::Parser.chain(pair.children[1])
           end
           result

--- a/lib/solargraph/pin/keyword.rb
+++ b/lib/solargraph/pin/keyword.rb
@@ -4,7 +4,6 @@ module Solargraph
   module Pin
     class Keyword < Base
       def initialize(name, **kwargs)
-        # @sg-ignore "Unrecognized keyword argument kwargs to Solargraph::Pin::Base#initialize"
         super(name: name, **kwargs)
       end
 

--- a/lib/solargraph/pin/symbol.rb
+++ b/lib/solargraph/pin/symbol.rb
@@ -7,7 +7,6 @@ module Solargraph
       # @param name [String]
       # @param [Hash{Symbol => Object}] kwargs
       def initialize(location, name, **kwargs)
-        # @sg-ignore "Unrecognized keyword argument kwargs to Solargraph::Pin::Base#initialize"
         super(location: location, name: name, **kwargs)
         # @name = name
         # @location = location

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -435,6 +435,13 @@ module Solargraph
     # @return [Array<Problem>]
     def signature_argument_problems_for location, locals, closure_pin, params, arguments, sig, pin
       errors = []
+      splat_keywords, unverifiable_splat = keyword_splat_types(arguments.last, closure_pin, locals)
+      # @sg-ignore "Wrong argument type for
+      #   Solargraph::TypeChecker#keyword_splat_problems_for: unverifiable_splat
+      #   expected Solargraph::ComplexType, nil, received Hash{Symbol =>
+      #   Solargraph::ComplexType}" - multiple assignment from an Array(A, B)
+      #   return type gives every variable the type of the first element
+      errors.concat keyword_splat_problems_for(sig, pin, location, arguments, splat_keywords, unverifiable_splat)
       # @todo add logic mapping up restarg parameters with
       #   arguments (including restarg arguments).  Use tuples
       #   when possible, and when not, ensure provably
@@ -489,10 +496,16 @@ module Solargraph
               end
             end
           else
-            errors.concat kwarg_problems_for sig, argchain, api_map, closure_pin, locals, location, pin, params, idx
+            # @sg-ignore "Wrong argument type for
+            #   Solargraph::TypeChecker#kwarg_problems_for: unverifiable_splat
+            #   expected Solargraph::ComplexType, nil, received Hash{Symbol =>
+            #   Solargraph::ComplexType}" - multiple assignment from an
+            #   Array(A, B) return type gives every variable the first element's type
+            errors.concat kwarg_problems_for(sig, argchain, api_map, closure_pin, locals, location, pin, params,
+                                             idx, splat_keywords, unverifiable_splat)
             next
           end
-        elsif par.decl == :kwarg
+        elsif par.decl == :kwarg && unverifiable_splat.nil?
           errors.push Problem.new(location, "Call to #{pin.path} is missing keyword argument #{par.name}")
           next
         end
@@ -509,38 +522,166 @@ module Solargraph
     # @param pin [Pin::Method]
     # @param params [Hash{String => Hash{Symbol => undefined}}]
     # @param idx [Integer]
+    # @param splat_keywords [Hash{Symbol => ComplexType}] keywords a `**` splat records in its type
+    # @param unverifiable_splat [ComplexType, nil] the type of a `**` splat that records no keys
     #
     # @return [Array<Problem>]
-    def kwarg_problems_for sig, argchain, api_map, closure_pin, locals, location, pin, params, idx
+    def kwarg_problems_for sig, argchain, api_map, closure_pin, locals, location, pin, params, idx, splat_keywords,
+                           unverifiable_splat
       result = []
       kwargs = convert_hash(argchain.node)
+      # idx comes from an each_with_index over these same parameters.
+      #
+      # @sg-ignore "Declared type Solargraph::Pin::Parameter does not match
+      #   inferred type Solargraph::Pin::Parameter, nil for variable par"
+      # @type [Pin::Parameter]
       par = sig.parameters[idx]
-      # @type [Solargraph::Source::Chain]
-      argchain = kwargs[par.name.to_sym]
       if par.decl == :kwrestarg || (par.decl == :optarg && idx == pin.parameters.length - 1 && par.asgn_code == '{}')
-        result.concat kwrestarg_problems_for(api_map, closure_pin, locals, location, pin, params, kwargs)
-      elsif argchain
-        data = params[par.name]
-        if data.nil?
-          # @todo Some level (strong, I guess) should require the param here
-        else
-          # @type [ComplexType, ComplexType::UniqueType]
-          ptype = data[:qualified]
-          ptype = ptype.self_to_type(pin.context)
-          unless ptype.undefined?
-            # @type [ComplexType]
-            argtype = argchain.infer(api_map, closure_pin, locals).self_to_type(closure_pin.context)
-            # @todo Unresolved call to defined?
-            if argtype.defined? && ptype && !arg_conforms_to?(argtype, ptype)
-              result.push Problem.new(location,
-                                      "Wrong argument type for #{pin.path}: #{par.name} expected #{ptype}, received #{argtype}")
-            end
-          end
+        return kwrestarg_problems_for(api_map, closure_pin, locals, location, pin, params, kwargs)
+      end
+      # @type [Solargraph::Source::Chain, nil]
+      valuechain = kwargs[par.name.to_sym]
+      argtype = if valuechain
+                  valuechain.infer(api_map, closure_pin, locals).self_to_type(closure_pin.context)
+                else
+                  splat_keywords[par.name.to_sym]
+                end
+      if argtype.nil?
+        if par.decl == :kwarg && unverifiable_splat.nil?
+          result.push Problem.new(location, "Call to #{pin.path} is missing keyword argument #{par.name}")
         end
-      elsif par.decl == :kwarg
-        result.push Problem.new(location, "Call to #{pin.path} is missing keyword argument #{par.name}")
+        return result
+      end
+      data = params[par.name]
+      # @todo Some level (strong, I guess) should require the param here
+      return result if data.nil?
+
+      # @type [ComplexType, ComplexType::UniqueType]
+      ptype = data[:qualified]
+      ptype = ptype.self_to_type(pin.context)
+      return result if ptype.undefined?
+
+      # @sg-ignore "Unresolved call to defined?" and "Wrong argument type for
+      #   Solargraph::TypeChecker#arg_conforms_to?: inferred expected
+      #   Solargraph::ComplexType, Solargraph::ComplexType::UniqueType, received
+      #   Solargraph::ComplexType, nil" - the nil case returned above
+      if argtype.defined? && !arg_conforms_to?(argtype, ptype)
+        result.push Problem.new(location,
+                                "Wrong argument type for #{pin.path}: #{par.name} expected #{ptype}, received #{argtype}")
       end
       result
+    end
+
+    # Problems that belong to the call as a whole rather than to one
+    # keyword parameter: a `**` splat whose type records no keys, and
+    # keys a record type supplies that the method does not accept.
+    #
+    # @param sig [Pin::Signature]
+    # @param pin [Pin::Method]
+    # @param location [Location]
+    # @param arguments [Array<Source::Chain>]
+    # @param splat_keywords [Hash{Symbol => ComplexType}]
+    # @param unverifiable_splat [ComplexType, nil]
+    # @return [Array<Problem>]
+    def keyword_splat_problems_for sig, pin, location, arguments, splat_keywords, unverifiable_splat
+      keyword_params = sig.parameters.select(&:keyword?)
+      return [] if keyword_params.empty?
+
+      if unverifiable_splat
+        unverified = keyword_params.select { |par| par.decl == :kwarg }.map(&:name) -
+                     convert_hash(arguments.last&.node).keys.map(&:to_s)
+        return [] if unverified.empty?
+
+        return [Problem.new(location, unverifiable_splat_message(pin, unverifiable_splat, unverified))]
+      end
+      return [] if splat_keywords.empty? || sig.parameters.any?(&:kwrestarg?)
+
+      unrecognized = splat_keywords.keys.reject { |name| keyword_params.any? { |par| par.name.to_sym == name } }
+      return [] if unrecognized.empty?
+
+      [Problem.new(location, "Unrecognized keyword argument #{unrecognized.first} to #{pin.path}")]
+    end
+
+    # @param pin [Pin::Method]
+    # @param type [ComplexType]
+    # @param unverified [Array<String>] required keywords the splat may or may not supply
+    # @return [String]
+    def unverifiable_splat_message pin, type, unverified
+      "Cannot verify keyword arguments to #{pin.path}: the ** splat is #{type}, which does not record its keys, " \
+        "so required keyword #{unverified.length == 1 ? 'argument' : 'arguments'} #{unverified.join(', ')} " \
+        'cannot be checked - give the splatted value a record type ' \
+        "(e.g. Hash{:#{unverified.first} => Object}) to check it"
+    end
+
+    # The keywords a call's `**` splats record in their types.
+    #
+    # A splat of a literal hash is not included: its keys are in the node
+    # itself, and #convert_hash already has them.
+    #
+    # @param argchain [Source::Chain, nil] the call's final argument
+    # @param closure_pin [Pin::Closure]
+    # @param locals [Array<Pin::LocalVariable>]
+    # @return [Array(Hash{Symbol => ComplexType}, ComplexType), Array(Hash{Symbol => ComplexType}, nil)]
+    #   the keywords found, and the type of the first splat that records no keys
+    def keyword_splat_types argchain, closure_pin, locals
+      node = argchain&.node
+      # @sg-ignore Translate to something flow sensitive typing understands
+      return [{}, nil] unless Parser.is_ast_node?(node) && node.type == :hash
+
+      keywords = {}
+      # @sg-ignore Translate to something flow sensitive typing understands
+      node.children.each do |child|
+        next unless Parser.is_ast_node?(child) && child.type == :kwsplat
+        inner = child.children[0]
+        next if Parser.is_ast_node?(inner) && inner.type == :hash
+
+        type = Solargraph::Parser.chain(inner).infer(api_map, closure_pin, locals)
+        recorded = recorded_keyword_types(type)
+        return [{}, type] if recorded.nil?
+
+        keywords.merge!(recorded)
+      end
+      [keywords, nil]
+    end
+
+    # The keyword names and value types a record type records - e.g.
+    # `Hash{:a => Integer} & Hash{:b => String}` records a as Integer and
+    # b as String - or nil if the type does not record its keys.
+    #
+    # @param type [ComplexType]
+    # @return [Hash{Symbol => ComplexType}, nil]
+    def recorded_keyword_types type
+      return nil if type.undefined? || type.items.empty?
+
+      keywords = {}
+      type.items.each do |item|
+        conjuncts = item.is_a?(ComplexType::UniqueType::Intersection) ? item.conjuncts : [ComplexType.new([item])]
+        conjuncts.each do |conjunct|
+          conjunct.items.each do |unique_type|
+            recorded = symbol_keyed_entries(unique_type)
+            return nil if recorded.nil?
+
+            keywords.merge!(recorded)
+          end
+        end
+      end
+      keywords
+    end
+
+    # @param unique_type [ComplexType::UniqueType]
+    # @return [Hash{Symbol => ComplexType}, nil]
+    def symbol_keyed_entries unique_type
+      return nil unless unique_type.name == 'Hash'
+      return nil if unique_type.key_types.empty? || unique_type.key_types.length != unique_type.subtypes.length
+
+      entries = {}
+      unique_type.key_types.each_with_index do |key_type, i|
+        tags = key_type.items.map(&:tag)
+        return nil unless tags.length == 1 && tags.first.start_with?(':')
+
+        entries[tags.first[1..].to_sym] = unique_type.subtypes[i]
+      end
+      entries
     end
 
     # @param api_map [ApiMap]

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -947,6 +947,24 @@ describe 'YARD type specifier list parsing' do
       expect(qualified.to_rbs).to eq('::Hash[::String, ::Foo::Bar]')
     end
 
+    it 'keeps the literal keys of a record type when qualifying' do
+      original = Solargraph::ComplexType.parse('Hash{:a => Bar}').first
+      qualified = original.qualify(foo_bar_api_map, 'Foo')
+      expect(qualified.tag).to eq('Hash{:a => Foo::Bar}')
+    end
+
+    it 'keeps the literal keys of each conjunct of a record intersection when qualifying' do
+      original = Solargraph::ComplexType.parse('Hash{:a => Bar} & Hash{:b => String}').first
+      qualified = original.qualify(foo_bar_api_map, 'Foo')
+      expect(qualified.rooted_tag).to eq('::Hash{:a => ::Foo::Bar} & ::Hash{:b => ::String}')
+    end
+
+    it 'still widens a literal that is not a key when qualifying' do
+      original = Solargraph::ComplexType.parse('Array<:a>').first
+      qualified = original.qualify(foo_bar_api_map, 'Foo')
+      expect(qualified.rooted_tag).to eq('::Array<::Symbol>')
+    end
+
     it 'parses tuples of tuples with same type twice in a row' do
       type = Solargraph::ComplexType.parse('Array(Symbol, String, Array(Integer, Integer))')
       expect(type.tag).to eq('Array(Symbol, String, Array(Integer, Integer))')

--- a/spec/parser/node_methods_spec.rb
+++ b/spec/parser/node_methods_spec.rb
@@ -346,6 +346,24 @@ describe Solargraph::Parser::NodeMethods do
       hash = described_class.convert_hash(node)
       expect(hash).to eq({})
     end
+
+    it 'keeps literal keys alongside an opaque ** splat' do
+      node = parse('some_call(foo: :bar, **args)').children[2]
+      hash = described_class.convert_hash(node)
+      expect(hash.keys).to eq([:foo])
+    end
+
+    it 'keeps literal keys given after an opaque ** splat' do
+      node = parse('some_call(**args, foo: :bar)').children[2]
+      hash = described_class.convert_hash(node)
+      expect(hash.keys).to eq([:foo])
+    end
+
+    it 'collects the keys of a splatted literal hash' do
+      node = parse('some_call(**{foo: :bar})').children[2]
+      hash = described_class.convert_hash(node)
+      expect(hash.keys).to eq([:foo])
+    end
   end
 
   describe 'call_nodes_from' do

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -304,6 +304,199 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to be_empty
     end
 
+    it 'reports a ** splat whose type records no keys as unverifiable, not missing' do
+      checker = type_checker(%(
+        # @param a [Integer]
+        # @param b [Integer]
+        # @return [void]
+        def foo(a:, b:); end
+
+        # @return [Hash{Symbol => Integer}]
+        def make_args
+          { a: 1, b: 2 }
+        end
+
+        # @return [void]
+        def bar
+          args = make_args
+          foo(**args)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq(
+        ['Cannot verify keyword arguments to #foo: the ** splat is Hash{Symbol => Integer}, which does not ' \
+         'record its keys, so required keyword arguments a, b cannot be checked - give the splatted value a ' \
+         'record type (e.g. Hash{:a => Object}) to check it']
+      )
+    end
+
+    it 'names only the required keywords a ** splat has to supply' do
+      checker = type_checker(%(
+        # @param a [Integer]
+        # @param b [Integer]
+        # @return [void]
+        def foo(a:, b:); end
+
+        # @return [Hash{Symbol => Integer}]
+        def make_args
+          { b: 2 }
+        end
+
+        # @return [void]
+        def bar
+          args = make_args
+          foo(a: 1, **args)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq(
+        ['Cannot verify keyword arguments to #foo: the ** splat is Hash{Symbol => Integer}, which does not ' \
+         'record its keys, so required keyword argument b cannot be checked - give the splatted value a ' \
+         'record type (e.g. Hash{:b => Object}) to check it']
+      )
+    end
+
+    it 'accepts required keywords supplied by a record-typed ** splat' do
+      checker = type_checker(%(
+        # @param a [Integer]
+        # @param b [Integer]
+        # @return [void]
+        def foo(a:, b:); end
+
+        # @return [Hash{:a => Integer} & Hash{:b => Integer}]
+        def make_args
+          { a: 1, b: 2 }
+        end
+
+        # @return [void]
+        def bar
+          args = make_args
+          foo(**args)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'accepts a record-typed ** splat that supplies what the literal keywords do not' do
+      checker = type_checker(%(
+        # @param a [Integer]
+        # @param b [Integer]
+        # @return [void]
+        def foo(a:, b:); end
+
+        # @return [Hash{:b => Integer}]
+        def make_args
+          { b: 2 }
+        end
+
+        # @return [void]
+        def bar
+          args = make_args
+          foo(a: 1, **args)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'reports a keyword a record-typed ** splat leaves out' do
+      checker = type_checker(%(
+        # @param a [Integer]
+        # @param b [Integer]
+        # @return [void]
+        def foo(a:, b:); end
+
+        # @return [Hash{:a => Integer}]
+        def make_args
+          { a: 1 }
+        end
+
+        # @return [void]
+        def bar
+          args = make_args
+          foo(**args)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq(['Call to #foo is missing keyword argument b'])
+    end
+
+    it 'checks the value types a record-typed ** splat supplies' do
+      checker = type_checker(%(
+        # @param a [Integer]
+        # @param b [Integer]
+        # @return [void]
+        def foo(a:, b:); end
+
+        # @return [Hash{:a => String} & Hash{:b => Integer}]
+        def make_args
+          { a: 'x', b: 2 }
+        end
+
+        # @return [void]
+        def bar
+          args = make_args
+          foo(**args)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq(
+        ['Wrong argument type for #foo: a expected Integer, received String']
+      )
+    end
+
+    it 'reports a keyword a record-typed ** splat supplies that the method does not accept' do
+      checker = type_checker(%(
+        # @param a [Integer]
+        # @param b [Integer]
+        # @return [void]
+        def foo(a:, b:); end
+
+        # @return [Hash{:a => Integer} & Hash{:b => Integer} & Hash{:c => Integer}]
+        def make_args
+          { a: 1, b: 2, c: 3 }
+        end
+
+        # @return [void]
+        def bar
+          args = make_args
+          foo(**args)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq(['Unrecognized keyword argument c to #foo'])
+    end
+
+    it 'still reports a keyword left out of a splatted literal hash' do
+      checker = type_checker(%(
+        # @param a [Integer]
+        # @param b [Integer]
+        # @return [void]
+        def foo(a:, b:); end
+
+        # @return [void]
+        def bar
+          foo(**{ a: 1 })
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq(['Missing keyword argument b to #foo'])
+    end
+
+    it 'does not invent a keyword named after the splatted variable' do
+      checker = type_checker(%(
+        class Base
+          # @param name [String]
+          # @param foo [Integer]
+          # @return [void]
+          def initialize(name:, foo: 1); end
+        end
+
+        class Sub < Base
+          # @param name [String]
+          # @param kwargs [Hash{Symbol => Object}]
+          # @return [void]
+          def initialize(name, **kwargs)
+            super(name: name, **kwargs)
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'calls out type issues even when keyword issues are there' do
       pending('fixes to arg vs param checking algorithm')
 


### PR DESCRIPTION
Passing a hash through `**` currently produces one false `missing keyword argument` finding per declared keyword, because the splatted hash's keys are invisible to the checker. This makes those calls checkable instead: a record-typed splat has its required keywords, value types and unrecognised keys verified for real, and an opaque splat produces a single diagnostic in place of N false ones — only where a *required* keyword is supplied by neither a literal key nor a record type. An opaque splat into a method with only optional keywords stays silent.

The enabling change is in `ComplexType::UniqueType#qualify`, which widened every literal, so `Hash{:a => Integer}` reached the checker as `Hash{Symbol => Integer}` and record types were erased before anything could use them. Preserving literals wholesale broke 11 specs, so this narrows it to keys only. `Intersection` gets its own `qualify`, since it holds conjuncts rather than key types and subtypes.

Stacked on https://github.com/castwide/solargraph/pull/1231 and cannot merge before it.

This PR was written by Claude Code on behalf of @apiology.
