### PR TITLE
Narrow is_a? checks joined by || to their union type

### DIFF
--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -65,7 +65,11 @@ module Solargraph
         # false, so provide false ranges to assert facts on
 
         # can't assume if an or is true that every single condition is
-        # true, so don't provide true ranges to assert facts on
+        # true, so don't provide true ranges to assert facts on to
+        # each side individually - however, if both sides are
+        # `is_a?` checks on the same variable, we can narrow that
+        # variable to the union of the checked types
+        process_or_isa_union(or_node, lhs, rhs, true_ranges)
 
         process_expression(lhs, [], false_ranges + [rhs_presence])
         process_expression(rhs, [], false_ranges)
@@ -332,6 +336,45 @@ module Solargraph
         if_false[pin] ||= []
         if_false[pin] << { not_type: ComplexType.parse(isa_type_name) }
         process_facts(if_false, false_presences)
+      end
+
+      # Handles the one case where an `||`-joined pair of conditions
+      # can still narrow the true branch: both sides are plain
+      # `is_a?` checks on the *same* variable. In that case the
+      # variable's type can be narrowed to the union of the two
+      # checked types. Any other shape (different variables, or
+      # either side not a plain `is_a?` call) is left alone rather
+      # than guessing at an unsound narrowing.
+      #
+      # @param or_node [Parser::AST::Node]
+      # @param lhs [Parser::AST::Node]
+      # @param rhs [Parser::AST::Node]
+      # @param true_ranges [Array<Range>]
+      #
+      # @return [void]
+      def process_or_isa_union or_node, lhs, rhs, true_ranges
+        return if true_ranges.empty?
+
+        lhs_type_name, lhs_variable_name = parse_isa(lhs)
+        return if lhs_variable_name.nil? || lhs_variable_name.empty?
+
+        rhs_type_name, rhs_variable_name = parse_isa(rhs)
+        return if rhs_variable_name.nil? || rhs_variable_name.empty?
+
+        # only sound to narrow when both sides test the same variable
+        return unless lhs_variable_name == rhs_variable_name
+
+        # @sg-ignore Need to add nil check here
+        or_position = Range.from_node(or_node).start
+
+        pin = find_var(lhs_variable_name, or_position)
+        return unless pin
+
+        # @type Hash{Pin::BaseVariable => Array<Hash{Symbol => ComplexType}>}
+        if_true = {}
+        if_true[pin] ||= []
+        if_true[pin] << { type: ComplexType.parse(lhs_type_name, rhs_type_name) }
+        process_facts(if_true, true_ranges)
       end
 
       # @param nilp_node [Parser::AST::Node]

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -1025,4 +1025,64 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     clip = api_map.clip_at('test.rb', [13, 12])
     expect(clip.infer.to_s).to eq('ReproBase')
   end
+
+  it 'uses is_a? in an || to narrow to the union of both checked types' do
+    source = Solargraph::Source.load_string(%(
+      class Repro
+        # @param e [Array<Symbol>, String]
+        # @return [void]
+        def eval_function_call(e); end
+
+        # @param e [Array<Symbol>, String, Integer]
+        # @return [void]
+        def eval(e)
+          if e.is_a?(Array) || e.is_a?(String)
+            e
+          end
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [10, 12])
+    expect(clip.infer.to_s).to eq('Array<Symbol>, String')
+  end
+
+  it 'does not narrow via || when only one side of the check is is_a? (negative control)' do
+    source = Solargraph::Source.load_string(%(
+      class Repro
+        # @param e [Array<Symbol>, String]
+        # @return [void]
+        def eval_function_call(e); end
+
+        # @param e [Array<Symbol>, String, Integer]
+        # @return [void]
+        def eval(e)
+          if e.is_a?(Array)
+            e
+          end
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [10, 12])
+    expect(clip.infer.to_s).to eq('Array<Symbol>')
+  end
+
+  it 'does not invent a narrowing across || when the two is_a? checks test different variables (soundness control)' do
+    source = Solargraph::Source.load_string(%(
+      class Repro
+        # @param x [Array<Symbol>, Integer]
+        # @param y [String, Integer]
+        # @return [void]
+        def eval(x, y)
+          if x.is_a?(Array) || y.is_a?(String)
+            x
+          end
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 12])
+    expect(clip.infer.to_s).to eq('Array<Symbol>, Integer')
+  end
 end


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

`FlowSensitiveTyping#process_or` never computed any true-branch (positive) narrowing for an `||`-joined condition — its own comment notes "can't assume if an or is true that every single condition is true, so don't provide true ranges to assert facts on." That's correct in general, but it means `if e.is_a?(Array) || e.is_a?(String)` never narrows `e` inside the `if` body at all, even though the disjunction does guarantee `e` is one of `Array | String` there.

Example that fails `solargraph typecheck --level strong` on master:
```ruby
class Repro
  # @param e [Array<Symbol>, String]
  def eval_function_call(e); end

  # @param e [Array<Symbol>, String, Integer]
  def eval(e)
    if e.is_a?(Array) || e.is_a?(String)
      eval_function_call(e)  # reports e as Array<Symbol>, String, Integer — the full param type, unnarrowed
    end
  end
end
```

This adds narrowing for the one case that's sound to infer generically: both sides of the `||` are plain `is_a?` calls on the *same* variable. In that case the variable is narrowed to the union of the two checked types on the true branch. Any other shape — different variables on each side, or either side not a plain `is_a?` call — is left exactly as before (no narrowing), rather than guessing.

**Known limitation:** a chain of three or more `is_a?` checks (`a.is_a?(X) || a.is_a?(Y) || a.is_a?(Z)`) still gets no narrowing, because the AST nests as `(X || Y) || Z` and the outer left-hand side is an `:or` node, not a `:send`, so `parse_isa` returns nil on it. This degrades to today's (no-narrowing) behavior rather than narrowing incorrectly, but a future PR could recurse to handle it.

Adds three specs to `spec/parser/flow_sensitive_typing_spec.rb`: the positive union case, a negative control (single `is_a?`, unaffected), and a soundness control (different variables on each side of the `||`, still unnarrowed).
