### PR TITLE
Fix Hash#fetch generic leak from unmatched RBS interface overloads

### DIFF
--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,10 +227,18 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
+        # :allow_unmatched_interface is included so that an
+        # RBS-interface-typed parameter (e.g. Hash#fetch's `_Key`) doesn't
+        # reject every argument that isn't nominally included in that
+        # interface via CoreFills::INCLUDES. Without it, no overload of a
+        # method like Hash#fetch ever matches a plain argument, and
+        # Pin::Method#return_type falls back to unioning every overload's
+        # return type together - including unbound generics from
+        # overloads that were never actually selected.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,
-                                          %i[allow_empty_params allow_undefined])
+                                          %i[allow_empty_params allow_undefined allow_unmatched_interface])
         ptype.generic?
       end
 

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -101,6 +101,32 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to be_empty
     end
 
+    it 'does not leak an unbound generic from an unmatched Hash#fetch overload' do
+      checker = type_checker(%(
+        class A
+          # @param b [Hash{String => Integer}]
+          # @return [Integer]
+          def a b
+            b.fetch('x')
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'infers nil as part of Hash#[] on a plainly-typed Hash' do
+      checker = type_checker(%(
+        class A
+          # @param b [Hash{String => Integer}]
+          # @return [Integer, nil]
+          def a b
+            b['x']
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'respects pin visibility in if/nil? pattern' do
       checker = type_checker(%(
         class Foo


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

Fixes castwide/solargraph#1227

## Summary

`Pin::Parameter#compatible_arg?` rejected every argument against an RBS-interface-typed parameter (e.g. `Hash#fetch`'s `_Key`) unless the argument's type was nominally included via `CoreFills::INCLUDES`. Since `Hash#fetch`'s plain (no default, no block) overload takes a `_Key`-typed parameter, no overload of `h.fetch(k)` ever matched during argument-type inference, and `Pin::Method#return_type` fell back to unioning *every* overload's return type together — leaking the unbound generic `X` from the default-value and block overloads into the inferred type.

```ruby
# @param h [Hash{String => Integer}]
# @return [Integer]
def fetch_it(h)
  h.fetch('a')
end
```
was reported as inferring `::Integer, generic<X>` against the declared `::Integer` return.

## Fix

Add `:allow_unmatched_interface` to the rules passed to `conforms_to?` in `compatible_arg?`, matching the leniency `TypeChecker` already applies by default everywhere except its `:alpha` level (`Rules#require_interfaces_resolved?`). This is scoped to overload argument matching only — `compatible_arg?` has a single call site (`Source::Chain::Call#inferred_pins`).

## Test plan

- [x] Added specs in `spec/type_checker/levels/strong_spec.rb` covering `Hash#fetch` (fixed) and `Hash#[]` (control, unaffected)
- [x] `bundle exec rspec` — 1626 examples, 0 failures, 60 pending (no new failures)
- [x] `bundle exec rubocop` on changed files — no offenses
