### PR TITLE
Resolve instance variable type when assigned only in an ancestor class's method

### DIFF
--- a/lib/solargraph/pin/instance_variable.rb
+++ b/lib/solargraph/pin/instance_variable.rb
@@ -33,6 +33,78 @@ module Solargraph
       def nearly? other
         super && binder == other.binder
       end
+
+      # BaseVariable#visible_at? requires the assignment and the read
+      # to be in the same file. That's correct whenever +presence+ is
+      # set (a flow-sensitive-narrowed range is only comparable to
+      # another position in the same file), but a plain, unnarrowed
+      # instance variable assignment has no +presence+ and can live in
+      # a different file than the read entirely - e.g. an ancestor
+      # class's method assigning the ivar, and a descendant class
+      # defined in its own file reading it. Only enforce the same-file
+      # requirement when +presence+ actually needs it.
+      #
+      # @param other_closure [Pin::Closure]
+      # @param other_loc [Location]
+      def visible_at? other_closure, other_loc
+        return false if presence && location&.filename != other_loc.filename
+        # @sg-ignore flow sensitive typing needs to handle attrs
+        return false if presence && !presence.include?(other_loc.range.start)
+
+        visible_in_closure?(other_closure)
+      end
+
+      private
+
+      # See if this variable is visible within 'viewing_closure'.
+      #
+      # BaseVariable's implementation walks the *lexical* nesting of
+      # +viewing_closure+ (method -> enclosing class/module -> ...)
+      # looking for a closure whose namespace matches this pin's own
+      # namespace, and gives up (returns false) once it reaches a
+      # Namespace pin with no match. That walk only reflects lexical
+      # nesting, not class inheritance, so it incorrectly hides an
+      # instance variable pin created in an ancestor class's method
+      # from a descendant class's method: the descendant's enclosing
+      # namespace is never lexically nested inside the ancestor's.
+      #
+      # #get_instance_variable_pins already restricts candidate pins
+      # to the reading namespace and its ancestors before
+      # ApiMap#var_at_location ever calls this method, so reaching a
+      # Namespace pin here with no closer (lexical or flow-sensitive)
+      # match means the pin is visible via inheritance - accept it
+      # instead of rejecting it.
+      #
+      # @param viewing_closure [Pin::Closure]
+      # @return [Boolean]
+      def visible_in_closure? viewing_closure
+        return false if closure.nil?
+
+        # if we're declared at top level, we can't be seen from within
+        # methods declared tere
+
+        # @sg-ignore Need to add nil check here
+        return false if viewing_closure.is_a?(Pin::Method) && closure.context.tags == 'Class<>'
+
+        # @sg-ignore Need to add nil check here
+        return true if viewing_closure.binder.namespace == closure.binder.namespace
+
+        # @sg-ignore Need to add nil check here
+        return true if viewing_closure.return_type == closure.context
+
+        # Unlike BaseVariable, don't stop here: an instance variable
+        # assigned in an ancestor class's method is still visible from
+        # a descendant class's method, and #get_instance_variable_pins
+        # already guarantees any candidate pin that reaches this point
+        # comes from the reading namespace or one of its ancestors.
+        return true if viewing_closure.is_a?(Pin::Namespace)
+
+        parent_of_viewing_closure = viewing_closure.closure
+
+        return false if parent_of_viewing_closure.nil?
+
+        visible_in_closure?(parent_of_viewing_closure)
+      end
     end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -882,6 +882,74 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to eq([])
     end
 
+    it 'resolves an ivar type when it is assigned only in an ancestor class method' do
+      checker = type_checker(%(
+        class WidgetBase
+          # @return [void]
+          def run
+            @name = 'set-in-run'
+          end
+        end
+
+        class Widget < WidgetBase
+          # @return [void]
+          def test_no_block
+            run
+            puts @name.upcase
+          end
+        end
+      ))
+
+      expect(checker.problems.map(&:message)).to eq([])
+    end
+
+    it 'resolves an ivar type when it is assigned and read within the same class' do
+      checker = type_checker(%(
+        class Widget
+          # @return [void]
+          def run
+            @name = 'set-in-run'
+          end
+
+          # @return [void]
+          def test_no_block
+            run
+            puts @name.upcase
+          end
+        end
+      ))
+
+      expect(checker.problems.map(&:message)).to eq([])
+    end
+
+    it 'resolves an ivar type across files when it is assigned only in an ancestor class method' do
+      base = Solargraph::Source.load_string(%(
+        class WidgetBase
+          # @return [void]
+          def run
+            @name = 'set-in-run'
+          end
+        end
+      ), 'widget_base.rb')
+      sub = Solargraph::Source.load_string(%(
+        class Widget < WidgetBase
+          # @return [void]
+          def test_no_block
+            run
+            puts @name.upcase
+          end
+        end
+      ), 'widget.rb')
+      api_map = Solargraph::ApiMap.new
+      api_map.catalog(Solargraph::Bench.new(source_maps: [
+                                              Solargraph::SourceMap.map(base),
+                                              Solargraph::SourceMap.map(sub)
+                                            ]))
+      checker = described_class.new('widget.rb', api_map: api_map, level: :strong)
+
+      expect(checker.problems.map(&:message)).to eq([])
+    end
+
     it 'supports !@x.nil && @x.y' do
       checker = type_checker(%(
         class Bar


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

Fixes castwide/solargraph#1261

`Pin::BaseVariable#visible_at?`/`#visible_in_closure?` treats every variable as lexically scoped, walking the closure nesting of the reading site and giving up once it reaches an enclosing `Namespace` pin with no matching binder namespace. `ApiMap#get_instance_variable_pins` already walks the superclass chain to gather ivar-assignment candidates from ancestor classes, but `var_at_location` discarded those candidates anyway, because a descendant class's namespace is never lexically nested inside its ancestor's.

`Pin::InstanceVariable` now overrides `visible_in_closure?` to accept a pin once the lexical walk bottoms out at a `Namespace` with no match, since `get_instance_variable_pins` has already restricted candidates to the reading namespace and its ancestors. It also overrides `visible_at?` so the same-file requirement only applies when `presence` (flow-sensitive narrowing) is actually set - a plain, unnarrowed ivar assignment can legitimately live in a different file than the read (e.g. an ancestor class defined in its own file).

Example that now typechecks cleanly at `--level strong`:

```ruby
class WidgetBase
  def run
    @name = 'set-in-run'
  end
end

class Widget < WidgetBase
  # @return [void]
  def test_no_block
    run
    puts @name.upcase
  end
end
```

Full spec suite: 1627 examples, 0 failures.
